### PR TITLE
【feature】ユーザーと認証のマイグレーション close #2

### DIFF
--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class User < ActiveRecord::Base
+  extend Devise::Models
+  devise :omniauthable, omniauth_providers: %i[google_oauth2]
+  include DeviseTokenAuth::Concerns::User
+end

--- a/back/config/initializers/devise_token_auth.rb
+++ b/back/config/initializers/devise_token_auth.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+DeviseTokenAuth.setup do |config|
+  # By default the authorization headers will change after each request. The
+  # client is responsible for keeping track of the changing tokens. Change
+  # this to false to prevent the Authorization header from changing after
+  # each request.
+  # config.change_headers_on_each_request = true
+
+  # By default, users will need to re-authenticate after 2 weeks. This setting
+  # determines how long tokens will remain valid after they are issued.
+  # config.token_lifespan = 2.weeks
+
+  # Limiting the token_cost to just 4 in testing will increase the performance of
+  # your test suite dramatically. The possible cost value is within range from 4
+  # to 31. It is recommended to not use a value more than 10 in other environments.
+  config.token_cost = Rails.env.test? ? 4 : 10
+
+  # Sets the max number of concurrent devices per user, which is 10 by default.
+  # After this limit is reached, the oldest tokens will be removed.
+  # config.max_number_of_devices = 10
+
+  # Sometimes it's necessary to make several requests to the API at the same
+  # time. In this case, each request in the batch will need to share the same
+  # auth token. This setting determines how far apart the requests can be while
+  # still using the same auth token.
+  # config.batch_request_buffer_throttle = 5.seconds
+
+  # This route will be the prefix for all oauth2 redirect callbacks. For
+  # example, using the default '/omniauth', the github oauth2 provider will
+  # redirect successful authentications to '/omniauth/github/callback'
+  # config.omniauth_prefix = "/omniauth"
+
+  # By default sending current password is not needed for the password update.
+  # Uncomment to enforce current_password param to be checked before all
+  # attribute updates. Set it to :password if you want it to be checked only if
+  # password is updated.
+  # config.check_current_password_before_update = :attributes
+
+  # By default we will use callbacks for single omniauth.
+  # It depends on fields like email, provider and uid.
+  # config.default_callbacks = true
+
+  # Makes it possible to change the headers names
+  # config.headers_names = {
+  #   :'authorization' => 'Authorization',
+  #   :'access-token' => 'access-token',
+  #   :'client' => 'client',
+  #   :'expiry' => 'expiry',
+  #   :'uid' => 'uid',
+  #   :'token-type' => 'token-type'
+  # }
+
+  # Makes it possible to use custom uid column
+  # config.other_uid = "foo"
+
+  # By default, only Bearer Token authentication is implemented out of the box.
+  # If, however, you wish to integrate with legacy Devise authentication, you can
+  # do so by enabling this flag. NOTE: This feature is highly experimental!
+  # config.enable_standard_devise_support = false
+
+  # By default DeviseTokenAuth will not send confirmation email, even when including
+  # devise confirmable module. If you want to use devise confirmable module and
+  # send email, set it to true. (This is a setting for compatibility)
+  # config.send_confirmation_email = true
+end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
+  mount_devise_token_auth_for 'User', at: 'auth'
   root 'application#index'
 end

--- a/back/db/migrate/20240608070210_devise_token_auth_create_users.rb
+++ b/back/db/migrate/20240608070210_devise_token_auth_create_users.rb
@@ -1,0 +1,22 @@
+class DeviseTokenAuthCreateUsers < ActiveRecord::Migration[7.1]
+  def change
+    create_table(:users) do |t|
+      ## Required
+      t.string :provider, :null => false, :default => "google_oauth2"
+      t.string :uid, :null => false, :default => ""
+
+      ## uuid
+      t.string :uuid, :null => false, :default => "UUID()"
+
+      ## User Info
+      t.string :name, :null => false, :default => "", limit: 10
+
+      ## Tokens
+      t.text :tokens
+
+      t.timestamps
+    end
+
+    add_index :users, [:uid, :provider],     unique: true
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -1,0 +1,25 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.1].define(version: 2024_06_08_070210) do
+  create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "provider", default: "google_oauth2", null: false
+    t.string "uid", default: "", null: false
+    t.string "uuid", default: "UUID()", null: false
+    t.string "name", limit: 10, default: "", null: false
+    t.text "tokens"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
+  end
+
+end


### PR DESCRIPTION
## 概要
DeviseTokenAuthを利用したユーザーテーブルのマイグレーションを使用しました。

## 紐づく issue
close #2 

## チェック項目
- [x] uid：ユニーク
- [x] provider
- [x] name：10文字バリデーション
- [x] タイムスタンプ

### 未実装の項目
- [ ] id：uuid形式

### 追加の実装項目
- [x] uuid：string、デフォルトはuuid

## 挙動
| DBのusersテーブルのカラム |
| --- |
| <img src="https://i.gyazo.com/e068588744fc0a5676e1aa2061fb3712.png" width="400px" /> |

## 補足
MySQLではuuid型がなかったのでstring（varchar）で対応しています。
idをuuidに変更するのはパフォーマンス低下の可能性があるようなので取りやめ、uuidカラムを別で用意しました。

## 参考
[第 11 章 データ型](https://dev.mysql.com/doc/refman/8.0/ja/data-types.html)
[MySQLでUUIDv4をプライマリキーにするとパフォーマンス問題が起きるのはなぜ？（N回目）](https://zenn.dev/reiwatravel/articles/9ce1050bf8509b)