### PR TITLE
【feature】Googleログイン機能追加 close #1

### DIFF
--- a/back/app/controllers/api/v1/auth/omniauth_callbacks_controller.rb
+++ b/back/app/controllers/api/v1/auth/omniauth_callbacks_controller.rb
@@ -1,0 +1,24 @@
+class Api::V1::Auth::OmniauthCallbacksController < DeviseTokenAuth::OmniauthCallbacksController
+  # オーバーライド
+  def redirect_callbacks
+    user = User.find_or_create_by_oauth(request.env['omniauth.auth'])
+    if user.persisted?
+      sign_in(:user, user)
+      # トークンを生成
+      client_id = SecureRandom.urlsafe_base64(nil, false)
+      token     = SecureRandom.urlsafe_base64(nil, false)
+      token_hash = BCrypt::Password.create(token)
+      expiry    = (Time.now + DeviseTokenAuth.token_lifespan).to_i
+
+      user.tokens[client_id] = {
+        token:  token_hash,
+        expiry: expiry
+      }
+      user.save
+
+      redirect_to "#{ENV['FRONT_URL']}/auth/callback?status=success&uid=#{user.uid}&token=#{token}&client=#{client_id}&expiry=#{expiry}", allow_other_host: true
+    else
+      redirect_to "#{ENV['FRONT_URL']}/auth/callback?status=failure", allow_other_host: true
+    end
+  end
+end

--- a/back/app/controllers/api/v1/auth/token_validations_controller.rb
+++ b/back/app/controllers/api/v1/auth/token_validations_controller.rb
@@ -1,0 +1,13 @@
+class Api::V1::Auth::TokenValidationsController < DeviseTokenAuth::OmniauthCallbacksController
+  protected
+
+  def render_validate_token_success
+    render json: {
+      success: true,
+      user: {
+        id: @resource.id,
+        name: @resource.name,
+      }
+    }
+  end
+end

--- a/back/app/controllers/api/v1/bases_controller.rb
+++ b/back/app/controllers/api/v1/bases_controller.rb
@@ -1,0 +1,3 @@
+class Api::V1::BasesController < ApplicationController
+  include DeviseTokenAuth::Concerns::SetUserByToken
+end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -4,4 +4,19 @@ class User < ActiveRecord::Base
   extend Devise::Models
   devise :omniauthable, omniauth_providers: %i[google_oauth2]
   include DeviseTokenAuth::Concerns::User
+
+  def self.find_or_create_by_oauth(auth)
+    transaction do
+      user = find_by(uid: auth.uid)
+      if user.nil?
+        newName = auth.info.name
+        if newName.length > 10
+          newName = newName[0..9]
+        end
+        user = User.new(uid: auth.uid, provider: auth.provider, name: newName)
+        user.save
+      end
+      user
+    end
+  end
 end

--- a/back/config/application.rb
+++ b/back/config/application.rb
@@ -40,5 +40,14 @@ module App
     # タイムゾーンを日本時間に設定
     config.time_zone = 'Tokyo'
     config.active_record.default_timezone = :local
+    # i18nの設定
+    config.i18n.default_locale = :ja
+    # Cookieを使うための設定
+    config.middleware.use ActionDispatch::Cookies
+    # セッションを使うための設定
+    config.middleware.use ActionDispatch::Session::CookieStore, key: '_kotonoha_tsuduri_token'
+    # Cookieで同じサイトを扱うための設定
+    config.action_dispatch.cookies_same_site_protection = :none
+    config.action_controller.forgery_protection_origin_check = false
   end
 end

--- a/back/config/initializers/devise.rb
+++ b/back/config/initializers/devise.rb
@@ -1,0 +1,320 @@
+# frozen_string_literal: true
+
+# Assuming you have not yet modified this file, each configuration option below
+# is set to its default value. Note that some are commented out while others
+# are not: uncommented lines are intended to protect your configuration from
+# breaking changes in upgrades (i.e., in the event that future versions of
+# Devise change the default values for those options).
+#
+# Use this hook to configure devise mailer, warden hooks and so forth.
+# Many of these configuration options can be set straight in your model.
+Devise.setup do |config|
+  # The secret key used by Devise. Devise uses this key to generate
+  # random tokens. Changing this key will render invalid all existing
+  # confirmation, reset password and unlock tokens in the database.
+  # Devise will use the `secret_key_base` as its `secret_key`
+  # by default. You can change it below and use your own secret key.
+  # config.secret_key = ''
+
+  # ==> Controller configuration
+  # Configure the parent class to the devise controllers.
+  # config.parent_controller = 'DeviseController'
+
+  # ==> Mailer Configuration
+  # Configure the e-mail address which will be shown in Devise::Mailer,
+  # note that it will be overwritten if you use your own mailer class
+  # with default "from" parameter.
+  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+
+  # Configure the class responsible to send e-mails.
+  # config.mailer = 'Devise::Mailer'
+
+  # Configure the parent class responsible to send e-mails.
+  # config.parent_mailer = 'ActionMailer::Base'
+
+  # ==> ORM configuration
+  # Load and configure the ORM. Supports :active_record (default) and
+  # :mongoid (bson_ext recommended) by default. Other ORMs may be
+  # available as additional gems.
+  require 'devise/orm/active_record'
+
+  # ==> Configuration for any authentication mechanism
+  # Configure which keys are used when authenticating a user. The default is
+  # just :email. You can configure it to use [:username, :subdomain], so for
+  # authenticating a user, both parameters are required. Remember that those
+  # parameters are used only when authenticating and not when retrieving from
+  # session. If you need permissions, you should implement that in a before filter.
+  # You can also supply a hash where the value is a boolean determining whether
+  # or not authentication should be aborted when the value is not present.
+  # config.authentication_keys = [:email]
+
+  # Configure parameters from the request object used for authentication. Each entry
+  # given should be a request method and it will automatically be passed to the
+  # find_for_authentication method and considered in your model lookup. For instance,
+  # if you set :request_keys to [:subdomain], :subdomain will be used on authentication.
+  # The same considerations mentioned for authentication_keys also apply to request_keys.
+  # config.request_keys = []
+
+  # Configure which authentication keys should be case-insensitive.
+  # These keys will be downcased upon creating or modifying a user and when used
+  # to authenticate or find a user. Default is :email.
+  config.case_insensitive_keys = [:email]
+
+  # Configure which authentication keys should have whitespace stripped.
+  # These keys will have whitespace before and after removed upon creating or
+  # modifying a user and when used to authenticate or find a user. Default is :email.
+  config.strip_whitespace_keys = [:email]
+
+  # Tell if authentication through request.params is enabled. True by default.
+  # It can be set to an array that will enable params authentication only for the
+  # given strategies, for example, `config.params_authenticatable = [:database]` will
+  # enable it only for database (email + password) authentication.
+  # config.params_authenticatable = true
+
+  # Tell if authentication through HTTP Auth is enabled. False by default.
+  # It can be set to an array that will enable http authentication only for the
+  # given strategies, for example, `config.http_authenticatable = [:database]` will
+  # enable it only for database authentication.
+  # For API-only applications to support authentication "out-of-the-box", you will likely want to
+  # enable this with :database unless you are using a custom strategy.
+  # The supported strategies are:
+  # :database      = Support basic authentication with authentication key + password
+  # config.http_authenticatable = false
+
+  # If 401 status code should be returned for AJAX requests. True by default.
+  # config.http_authenticatable_on_xhr = true
+
+  # The realm used in Http Basic Authentication. 'Application' by default.
+  # config.http_authentication_realm = 'Application'
+
+  # It will change confirmation, password recovery and other workflows
+  # to behave the same regardless if the e-mail provided was right or wrong.
+  # Does not affect registerable.
+  # config.paranoid = true
+
+  # By default Devise will store the user in session. You can skip storage for
+  # particular strategies by setting this option.
+  # Notice that if you are skipping storage for all authentication paths, you
+  # may want to disable generating routes to Devise's sessions controller by
+  # passing skip: :sessions to `devise_for` in your config/routes.rb
+  config.skip_session_storage = [:http_auth]
+
+  # By default, Devise cleans up the CSRF token on authentication to
+  # avoid CSRF token fixation attacks. This means that, when using AJAX
+  # requests for sign in and sign up, you need to get a new CSRF token
+  # from the server. You can disable this option at your own risk.
+  # config.clean_up_csrf_token_on_authentication = true
+
+  # When false, Devise will not attempt to reload routes on eager load.
+  # This can reduce the time taken to boot the app but if your application
+  # requires the Devise mappings to be loaded during boot time the application
+  # won't boot properly.
+  # config.reload_routes = true
+
+  # ==> Configuration for :database_authenticatable
+  # For bcrypt, this is the cost for hashing the password and defaults to 12. If
+  # using other algorithms, it sets how many times you want the password to be hashed.
+  # The number of stretches used for generating the hashed password are stored
+  # with the hashed password. This allows you to change the stretches without
+  # invalidating existing passwords.
+  #
+  # Limiting the stretches to just one in testing will increase the performance of
+  # your test suite dramatically. However, it is STRONGLY RECOMMENDED to not use
+  # a value less than 10 in other environments. Note that, for bcrypt (the default
+  # algorithm), the cost increases exponentially with the number of stretches (e.g.
+  # a value of 20 is already extremely slow: approx. 60 seconds for 1 calculation).
+  config.stretches = Rails.env.test? ? 1 : 12
+
+  # Set up a pepper to generate the hashed password.
+  # config.pepper = '4854d4b20de57dd05cc46299afaa9633270a7da584ddef09e1bce08234c346381585e91ebc9913d751883f482460ed8517e772f9705d61c120ec21b184c6edcb'
+
+  # Send a notification to the original email when the user's email is changed.
+  # config.send_email_changed_notification = false
+
+  # Send a notification email when the user's password is changed.
+  # config.send_password_change_notification = false
+
+  # ==> Configuration for :confirmable
+  # A period that the user is allowed to access the website even without
+  # confirming their account. For instance, if set to 2.days, the user will be
+  # able to access the website for two days without confirming their account,
+  # access will be blocked just in the third day.
+  # You can also set it to nil, which will allow the user to access the website
+  # without confirming their account.
+  # Default is 0.days, meaning the user cannot access the website without
+  # confirming their account.
+  # config.allow_unconfirmed_access_for = 2.days
+
+  # A period that the user is allowed to confirm their account before their
+  # token becomes invalid. For example, if set to 3.days, the user can confirm
+  # their account within 3 days after the mail was sent, but on the fourth day
+  # their account can't be confirmed with the token any more.
+  # Default is nil, meaning there is no restriction on how long a user can take
+  # before confirming their account.
+  # config.confirm_within = 3.days
+
+  # If true, requires any email changes to be confirmed (exactly the same way as
+  # initial account confirmation) to be applied. Requires additional unconfirmed_email
+  # db field (see migrations). Until confirmed, new email is stored in
+  # unconfirmed_email column, and copied to email column on successful confirmation.
+  config.reconfirmable = true
+
+  # Defines which key will be used when confirming an account
+  # config.confirmation_keys = [:email]
+
+  # ==> Configuration for :rememberable
+  # The time the user will be remembered without asking for credentials again.
+  # config.remember_for = 2.weeks
+
+  # Invalidates all the remember me tokens when the user signs out.
+  config.expire_all_remember_me_on_sign_out = true
+
+  # If true, extends the user's remember period when remembered via cookie.
+  # config.extend_remember_period = false
+
+  # Options to be passed to the created cookie. For instance, you can set
+  # secure: true in order to force SSL only cookies.
+  # config.rememberable_options = {}
+
+  # ==> Configuration for :validatable
+  # Range for password length.
+  config.password_length = 6..128
+
+  # Email regex used to validate email formats. It simply asserts that
+  # one (and only one) @ exists in the given string. This is mainly
+  # to give user feedback and not to assert the e-mail validity.
+  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+
+  # ==> Configuration for :timeoutable
+  # The time you want to timeout the user session without activity. After this
+  # time the user will be asked for credentials again. Default is 30 minutes.
+  # config.timeout_in = 30.minutes
+
+  # ==> Configuration for :lockable
+  # Defines which strategy will be used to lock an account.
+  # :failed_attempts = Locks an account after a number of failed attempts to sign in.
+  # :none            = No lock strategy. You should handle locking by yourself.
+  # config.lock_strategy = :failed_attempts
+
+  # Defines which key will be used when locking and unlocking an account
+  # config.unlock_keys = [:email]
+
+  # Defines which strategy will be used to unlock an account.
+  # :email = Sends an unlock link to the user email
+  # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
+  # :both  = Enables both strategies
+  # :none  = No unlock strategy. You should handle unlocking by yourself.
+  # config.unlock_strategy = :both
+
+  # Number of authentication tries before locking an account if lock_strategy
+  # is failed attempts.
+  # config.maximum_attempts = 20
+
+  # Time interval to unlock the account if :time is enabled as unlock_strategy.
+  # config.unlock_in = 1.hour
+
+  # Warn on the last attempt before the account is locked.
+  # config.last_attempt_warning = true
+
+  # ==> Configuration for :recoverable
+  #
+  # Defines which key will be used when recovering the password for an account
+  # config.reset_password_keys = [:email]
+
+  # Time interval you can reset your password with a reset password key.
+  # Don't put a too small interval or your users won't have the time to
+  # change their passwords.
+  config.reset_password_within = 6.hours
+
+  # When set to false, does not sign a user in automatically after their password is
+  # reset. Defaults to true, so a user is signed in automatically after a reset.
+  # config.sign_in_after_reset_password = true
+
+  # ==> Configuration for :encryptable
+  # Allow you to use another hashing or encryption algorithm besides bcrypt (default).
+  # You can use :sha1, :sha512 or algorithms from others authentication tools as
+  # :clearance_sha1, :authlogic_sha512 (then you should set stretches above to 20
+  # for default behavior) and :restful_authentication_sha1 (then you should set
+  # stretches to 10, and copy REST_AUTH_SITE_KEY to pepper).
+  #
+  # Require the `devise-encryptable` gem when using anything other than bcrypt
+  # config.encryptor = :sha512
+
+  # ==> Scopes configuration
+  # Turn scoped views on. Before rendering "sessions/new", it will first check for
+  # "users/sessions/new". It's turned off by default because it's slower if you
+  # are using only default views.
+  # config.scoped_views = false
+
+  # Configure the default scope given to Warden. By default it's the first
+  # devise role declared in your routes (usually :user).
+  # config.default_scope = :user
+
+  # Set this configuration to false if you want /users/sign_out to sign out
+  # only the current scope. By default, Devise signs out all scopes.
+  # config.sign_out_all_scopes = true
+
+  # ==> Navigation configuration
+  # Lists the formats that should be treated as navigational. Formats like
+  # :html should redirect to the sign in page when the user does not have
+  # access, but formats like :xml or :json, should return 401.
+  #
+  # If you have any extra navigational formats, like :iphone or :mobile, you
+  # should add them to the navigational formats lists.
+  #
+  # The "*/*" below is required to match Internet Explorer requests.
+  # config.navigational_formats = ['*/*', :html, :turbo_stream]
+
+  # The default HTTP method used to sign out a resource. Default is :delete.
+  config.sign_out_via = :delete
+
+  # ==> OmniAuth
+  # Add a new OmniAuth provider. Check the wiki for more information on setting
+  # up on your models and hooks.
+  # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+
+  # ==> Warden configuration
+  # If you want to use other strategies, that are not supported by Devise, or
+  # change the failure app, you can configure them inside the config.warden block.
+  #
+  # config.warden do |manager|
+  #   manager.intercept_401 = false
+  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
+  # end
+
+  # ==> Mountable engine configurations
+  # When using Devise inside an engine, let's call it `MyEngine`, and this engine
+  # is mountable, there are some extra configurations to be taken into account.
+  # The following options are available, assuming the engine is mounted as:
+  #
+  #     mount MyEngine, at: '/my_engine'
+  #
+  # The router that invoked `devise_for`, in the example above, would be:
+  # config.router_name = :my_engine
+  #
+  # When using OmniAuth, Devise cannot automatically set OmniAuth path,
+  # so you need to do it manually. For the users scope, it would be:
+  # config.omniauth_path_prefix = '/my_engine/users/auth'
+
+  # ==> Hotwire/Turbo configuration
+  # When using Devise with Hotwire/Turbo, the http status for error responses
+  # and some redirects must match the following. The default in Devise for existing
+  # apps is `200 OK` and `302 Found` respectively, but new apps are generated with
+  # these new defaults that match Hotwire/Turbo behavior.
+  # Note: These might become the new default in future versions of Devise.
+  config.responder.error_status = :unprocessable_entity
+  config.responder.redirect_status = :see_other
+
+  # ==> Configuration for :registerable
+
+  # When set to false, does not sign a user in automatically after their password is
+  # changed. Defaults to true, so a user is signed in automatically after changing a password.
+  # config.sign_in_after_change_password = true
+
+  # OmniAuth
+  config.omniauth :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET'], {
+    scope: 'profile',
+    provider_ignores_state: Rails.env.development?,
+    failure_redirect_url: '/api/v1/auth/failure'
+  }
+end

--- a/back/config/initializers/omniauth.rb
+++ b/back/config/initializers/omniauth.rb
@@ -1,0 +1,4 @@
+# config/initializers/omniauth.rb
+Rails.application.config.middleware.use OmniAuth::Builder do
+  OmniAuth.config.allowed_request_methods = [:get]
+end

--- a/back/config/locales/ja.yml
+++ b/back/config/locales/ja.yml
@@ -1,0 +1,21 @@
+ja:
+  activerecord:
+    models:
+      user: ユーザー
+    attributes:
+      user:
+        name: 名前
+        uid: uid
+        provider: provider
+        uuid: uuid
+    errors:
+      models:
+        user:
+          attributes:
+            name:
+              blank: が入力されていません
+              too_long: は%{count}文字以内で入力してください
+            uuid:
+              blank: が入力されていません
+              invalid: が不正です
+              uniqueness: は既に使用されています

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -1,4 +1,11 @@
 Rails.application.routes.draw do
-  mount_devise_token_auth_for 'User', at: 'auth'
+  namespace :api do
+    namespace :v1 do
+      mount_devise_token_auth_for 'User', at: 'auth', controllers: {
+        omniauth_callbacks: 'api/v1/auth/omniauth_callbacks',
+        token_validations:  'api/v1/auth/token_validations',
+      }
+    end
+  end
   root 'application#index'
 end

--- a/front/package.json
+++ b/front/package.json
@@ -11,12 +11,14 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "@types/js-cookie": "^3.0.6",
     "@typescript-eslint/eslint-plugin": "^7.12.0",
     "@typescript-eslint/parser": "^7.12.0",
     "axios": "^1.7.2",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-import": "^2.29.1",
     "husky": "^9.0.11",
+    "js-cookie": "^3.0.5",
     "lint-staged": "^15.2.5",
     "next": "14.2.3",
     "prettier": "^3.3.1",

--- a/front/prettier.config.js
+++ b/front/prettier.config.js
@@ -4,8 +4,7 @@ module.exports = {
     project: 'tsconfig.json',
   },
   plugins: ['prettier-plugin-tailwindcss'],
-  semi: false,
-  printWidth: 90,
+  printWidth: 100,
   tabWidth: 2,
   trailingComma: "all",
 }

--- a/front/src/app/auth/callback/page.tsx
+++ b/front/src/app/auth/callback/page.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useEffect } from "react";
+
+import { getEnv } from "@/config";
+
+export default function AuthCallbackPage() {
+  // https://nextjs.org/docs/app/api-reference/functions/use-search-params
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const parentWindow: Window | null = window.opener as (Window & typeof globalThis) | null;
+
+    if (!parentWindow) {
+      window.close();
+      return;
+    }
+
+    const status = searchParams.get("status");
+
+    if (status === "failure") {
+      parentWindow.postMessage({ status: "error" }, `${getEnv("URL")}/login`);
+      window.close();
+      return;
+    }
+
+    const accessToken = searchParams.get("token");
+    const uid = searchParams.get("uid");
+    const expiry = searchParams.get("expiry");
+    const client = searchParams.get("client");
+
+    if (accessToken && uid && expiry && client) {
+      parentWindow.postMessage({ accessToken, uid, expiry, client }, `${getEnv("URL")}/login`);
+      window.close();
+    }
+  }, []);
+}

--- a/front/src/app/auth/callback/page.tsx
+++ b/front/src/app/auth/callback/page.tsx
@@ -6,7 +6,6 @@ import { useEffect } from "react";
 import { getEnv } from "@/config";
 
 export default function AuthCallbackPage() {
-  // https://nextjs.org/docs/app/api-reference/functions/use-search-params
   const searchParams = useSearchParams();
 
   useEffect(() => {

--- a/front/src/app/auth/callback/page.tsx
+++ b/front/src/app/auth/callback/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { useSearchParams } from "next/navigation";
-import { useEffect } from "react";
+import { Suspense, useEffect } from "react";
 
 import { getEnv } from "@/config";
 
-export default function AuthCallbackPage() {
+function AuthCallbackPageContent() {
   const searchParams = useSearchParams();
 
   useEffect(() => {
@@ -34,4 +34,13 @@ export default function AuthCallbackPage() {
       window.close();
     }
   }, []);
+  return <></>;
+}
+
+export default function AuthCallbackPage() {
+  return (
+    <Suspense fallback={<></>}>
+      <AuthCallbackPageContent />
+    </Suspense>
+  );
 }

--- a/front/src/app/auth/failure/page.tsx
+++ b/front/src/app/auth/failure/page.tsx
@@ -1,0 +1,7 @@
+export default function Failure() {
+  return (
+    <div>
+      <h1>Failure</h1>
+    </div>
+  );
+}

--- a/front/src/app/globals.css
+++ b/front/src/app/globals.css
@@ -1,3 +1,123 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* ================================== */
+/*        Googleログインボタン        */
+/* ================================== */
+.gsi-material-button {
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  -webkit-appearance: none;
+  background-color: #f2f2f2;
+  background-image: none;
+  border: none;
+  -webkit-border-radius: 20px;
+  border-radius: 20px;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  color: #1f1f1f;
+  cursor: pointer;
+  font-family: "Roboto", arial, sans-serif;
+  font-size: 14px;
+  height: 40px;
+  letter-spacing: 0.25px;
+  outline: none;
+  overflow: hidden;
+  padding: 0 12px;
+  position: relative;
+  text-align: center;
+  -webkit-transition:
+    background-color 0.218s,
+    border-color 0.218s,
+    box-shadow 0.218s;
+  transition:
+    background-color 0.218s,
+    border-color 0.218s,
+    box-shadow 0.218s;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: auto;
+  max-width: 400px;
+  min-width: min-content;
+}
+
+.gsi-material-button .gsi-material-button-icon {
+  height: 20px;
+  margin-right: 12px;
+  min-width: 20px;
+  width: 20px;
+}
+
+.gsi-material-button .gsi-material-button-content-wrapper {
+  -webkit-align-items: center;
+  align-items: center;
+  display: flex;
+  -webkit-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  height: 100%;
+  justify-content: space-between;
+  position: relative;
+  width: 100%;
+}
+
+.gsi-material-button .gsi-material-button-contents {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  font-family: "Roboto", arial, sans-serif;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: top;
+}
+
+.gsi-material-button .gsi-material-button-state {
+  -webkit-transition: opacity 0.218s;
+  transition: opacity 0.218s;
+  bottom: 0;
+  left: 0;
+  opacity: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+
+.gsi-material-button:disabled {
+  cursor: default;
+  background-color: #ffffff61;
+}
+
+.gsi-material-button:disabled .gsi-material-button-state {
+  background-color: #1f1f1f1f;
+}
+
+.gsi-material-button:disabled .gsi-material-button-contents {
+  opacity: 38%;
+}
+
+.gsi-material-button:disabled .gsi-material-button-icon {
+  opacity: 38%;
+}
+
+.gsi-material-button:not(:disabled):active .gsi-material-button-state,
+.gsi-material-button:not(:disabled):focus .gsi-material-button-state {
+  background-color: #001d35;
+  opacity: 12%;
+}
+
+.gsi-material-button:not(:disabled):hover {
+  -webkit-box-shadow:
+    0 1px 2px 0 rgba(60, 64, 67, 0.3),
+    0 1px 3px 1px rgba(60, 64, 67, 0.15);
+  box-shadow:
+    0 1px 2px 0 rgba(60, 64, 67, 0.3),
+    0 1px 3px 1px rgba(60, 64, 67, 0.15);
+}
+
+.gsi-material-button:not(:disabled):hover .gsi-material-button-state {
+  background-color: #001d35;
+  opacity: 8%;
+}

--- a/front/src/app/login/page.tsx
+++ b/front/src/app/login/page.tsx
@@ -1,8 +1,81 @@
+"use client";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+import * as Config from "@/config";
+import { GoogleLoginButton } from "@/features/auth";
+import * as Lib from "@/lib";
+
 export default function Login() {
+  const router = useRouter();
+  const [isLogged, setIsLogged] = useState(false);
+  const url = Config.getEnv("API_URL");
+  const SECONDS = 1000;
+
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      // セキュリティのためオリジンを確認
+      if (event.origin !== Config.getEnv("URL")) return;
+
+      const data = event.data as
+        | { accessToken: string; uid: string; expiry: string; client: string }
+        | { status: string };
+
+      if ("accessToken" in data) {
+        const { accessToken, uid, expiry, client } = data;
+        Lib.setToken({ accessToken, uid, expiry, client });
+      }
+
+      setIsLogged(true);
+    };
+
+    window.addEventListener("message", handleMessage);
+
+    return () => {
+      window.removeEventListener("message", handleMessage);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isLogged) return;
+    const tokens = Lib.getToken();
+    console.log(tokens.accessToken, tokens.uid, tokens.expiry, tokens.client);
+    if (tokens.accessToken && tokens.uid && tokens.expiry && tokens.client) {
+      router.push(Config.Routes.home);
+      return;
+    }
+
+    router.push(Config.Routes.authFailure);
+  }, [isLogged]);
+
+  const handlePopup = () => {
+    const top = window.screenY + (window.outerHeight - 600) / 2;
+    const left = window.screenX + (window.outerWidth - 600) / 2;
+    const popup = window.open(
+      `${url}/auth/google_oauth2`,
+      "GoogleLogin",
+      `width=600,height=600,top=${top},left=${left}`,
+    );
+
+    if (!popup) {
+      return;
+    }
+
+    const intervalId = setInterval(() => {
+      if (popup.closed) {
+        clearInterval(intervalId);
+        setIsLogged(true);
+      }
+    }, SECONDS);
+  };
+
   return (
     <article>
       <section>
-        <h1>ログイン画面</h1>
+        <h1>筆をとる</h1>
+        <div>
+          <GoogleLoginButton onClick={handlePopup} />
+        </div>
       </section>
     </article>
   );

--- a/front/src/config/env.ts
+++ b/front/src/config/env.ts
@@ -1,0 +1,10 @@
+export default function getEnv(key: string) {
+  switch (key) {
+    case "API_URL":
+      return process.env.API_URL || process.env.NEXT_PUBLIC_API_URL || "";
+    case "URL":
+      return process.env.URL || process.env.NEXT_PUBLIC_URL || "";
+    default:
+      return "";
+  }
+}

--- a/front/src/config/index.ts
+++ b/front/src/config/index.ts
@@ -1,0 +1,4 @@
+import getEnv from "./env";
+import Routes from "./routesPath";
+
+export { getEnv, Routes };

--- a/front/src/config/routesPath.ts
+++ b/front/src/config/routesPath.ts
@@ -1,0 +1,9 @@
+const Routes = {
+  home: "/",
+  login: "/login",
+  users: "/users",
+  user: (id: string) => `/users/${id}`,
+  authFailure: "/auth/failure",
+};
+
+export default Routes;

--- a/front/src/features/auth/getUser/index.tsx
+++ b/front/src/features/auth/getUser/index.tsx
@@ -1,0 +1,18 @@
+import { axiosClient } from "@/lib";
+import { IUser } from "@/types";
+
+export const getUser = async () => {
+  try {
+    const res = await axiosClient().get("/auth/validate_token");
+    if (res.status !== 200 || !res.data) {
+      return null;
+    }
+
+    const user: IUser = (res.data as { user: IUser }).user;
+    console.log(user);
+    return user;
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+};

--- a/front/src/features/auth/googltLoginButton/index.tsx
+++ b/front/src/features/auth/googltLoginButton/index.tsx
@@ -1,0 +1,37 @@
+export default function GoogleLoginButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button type="button" className="gsi-material-button" onClick={() => onClick()}>
+      <div className="gsi-material-button-state"></div>
+      <div className="gsi-material-button-content-wrapper">
+        <div className="gsi-material-button-icon">
+          <svg
+            version="1.1"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 48 48"
+            xmlnsXlink="http://www.w3.org/1999/xlink"
+            style={{ display: "block" }}
+          >
+            <path
+              fill="#EA4335"
+              d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"
+            ></path>
+            <path
+              fill="#4285F4"
+              d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"
+            ></path>
+            <path
+              fill="#FBBC05"
+              d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"
+            ></path>
+            <path
+              fill="#34A853"
+              d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"
+            ></path>
+            <path fill="none" d="M0 0h48v48H0z"></path>
+          </svg>
+        </div>
+        <span className="gsi-material-button-contents">Googleでログイン</span>
+      </div>
+    </button>
+  );
+}

--- a/front/src/features/auth/index.ts
+++ b/front/src/features/auth/index.ts
@@ -1,0 +1,4 @@
+import { getUser } from "./getUser";
+import GoogleLoginButton from "./googltLoginButton";
+
+export { getUser, GoogleLoginButton };

--- a/front/src/lib/axiosClient/index.ts
+++ b/front/src/lib/axiosClient/index.ts
@@ -1,0 +1,27 @@
+import axios from "axios";
+
+import { getEnv } from "@/config";
+import { getToken } from "@/lib";
+
+export default function axiosClient() {
+  const tokens = getToken();
+  const client = axios.create({
+    baseURL: getEnv("API_URL") || getEnv("NEXT_PUBLIC_API_URL") || "",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+
+  // トークンセット
+  client.interceptors.request.use((config) => {
+    const newConfig = { ...config };
+    if (tokens.accessToken && tokens.uid && tokens.expiry && tokens.client) {
+      newConfig.headers["access-token"] = tokens.accessToken;
+      newConfig.headers.uid = tokens.uid;
+      newConfig.headers.expiry = tokens.expiry;
+      newConfig.headers.client = tokens.client;
+    }
+    return newConfig;
+  });
+  return client;
+}

--- a/front/src/lib/getToken/index.ts
+++ b/front/src/lib/getToken/index.ts
@@ -1,6 +1,5 @@
 import Cookies from "js-cookie";
 
-// https://nextjs.org/docs/app/api-reference/functions/cookies
 export default function getToken() {
   // アクセストークン
   const accessToken = Cookies.get("access-token");

--- a/front/src/lib/getToken/index.ts
+++ b/front/src/lib/getToken/index.ts
@@ -1,0 +1,23 @@
+import Cookies from "js-cookie";
+
+// https://nextjs.org/docs/app/api-reference/functions/cookies
+export default function getToken() {
+  // アクセストークン
+  const accessToken = Cookies.get("access-token");
+
+  // uid
+  const uid = Cookies.get("uid");
+
+  // expiry
+  const expiry = Cookies.get("expiry");
+
+  // client
+  const client = Cookies.get("client");
+
+  return {
+    accessToken: accessToken || "",
+    uid: uid || "",
+    expiry: expiry || "",
+    client: client || "",
+  };
+}

--- a/front/src/lib/index.ts
+++ b/front/src/lib/index.ts
@@ -1,0 +1,5 @@
+import axiosClient from "./axiosClient";
+import getToken from "./getToken";
+import setToken from "./setToken";
+
+export { axiosClient, getToken, setToken };

--- a/front/src/lib/setToken/index.ts
+++ b/front/src/lib/setToken/index.ts
@@ -1,0 +1,37 @@
+import Cookies from "js-cookie";
+
+export default function setToken({
+  accessToken,
+  uid,
+  expiry,
+  client,
+}: {
+  accessToken: string;
+  uid: string;
+  expiry: string;
+  client: string;
+}) {
+  // アクセストークン
+  Cookies.set("access-token", accessToken, {
+    path: "/",
+    expires: new Date(expiry),
+  });
+
+  // uid
+  Cookies.set("uid", uid, {
+    path: "/",
+    expires: new Date(expiry),
+  });
+
+  // expiry
+  Cookies.set("expiry", expiry, {
+    path: "/",
+    expires: new Date(expiry),
+  });
+
+  // client
+  Cookies.set("client", client, {
+    path: "/",
+    expires: new Date(expiry),
+  });
+}

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -1,0 +1,4 @@
+export interface IUser {
+  id: number;
+  name: string;
+}

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -210,6 +210,11 @@
     "@swc/counter" "^0.1.3"
     tslib "^2.4.0"
 
+"@types/js-cookie@^3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-3.0.6.tgz#a04ca19e877687bd449f5ad37d33b104b71fdf95"
+  integrity sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==
+
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
@@ -1852,6 +1857,11 @@ jiti@^1.21.0:
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.21.3.tgz#b2adb07489d7629b344d59082bbedb8c21c5f755"
   integrity sha512-uy2bNX5zQ+tESe+TiC7ilGRz8AtRGmnJH55NC5S0nSUjvvvM2hJHmefHErugGXN4pNv4Qx7vLsnNw9qJ9mtIsw==
 
+js-cookie@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.5.tgz#0b7e2fd0c01552c58ba86e0841f94dc2557dcdbc"
+  integrity sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==
+
 "js-tokens@^3.0.0 || ^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -2691,6 +2701,7 @@ string-argv@~0.3.2:
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==


### PR DESCRIPTION
## 概要
DeviseTokenAuthとOmniAuthによるGoogle認証を実装しました。
ユーザーテーブルにはuid、provider、nameを保存します。

## 紐づく issue
close #1 

## チェック項目
- [x] 【フロント】Googleでログインのボタンがある
- [ ] 【フロント・バック】認証ページへ飛ぶ
- [x] 【バック】認証後に登録、既存ユーザーならログイン処理
- [x] 【バック・フロント】ログイン結果がフロントに返ってくる
- [ ]  【フロント】ログイン結果をトースト表示する（「ログインしました」「ログインに失敗しました」）

### 未実装の項目
- [ ] 【フロント・バック】認証ページへ飛ぶ
   ⇨ ポップアップ認証に変更しました
- [ ]  【フロント】ログイン結果をトースト表示する（「ログインしました」「ログインに失敗しました」）
   ⇨ UIコンポーネントの選定がまだのため未実装です

## 挙動
| PC |
| --- |
| <img src="https://i.gyazo.com/326b50d10cae56a1629ee69cf6bf03dc.gif" width="400px" /> |

## 補足
スマホは実機で確認を行います。

## 参考
https://nextjs.org/docs/app/api-reference/functions/use-search-params
https://nextjs.org/docs/app/api-reference/functions/cookies