### PR TITLE
【feature】投稿のマイグレーション close #6

### DIFF
--- a/back/app/models/genre.rb
+++ b/back/app/models/genre.rb
@@ -1,0 +1,2 @@
+class Genre < ApplicationRecord
+end

--- a/back/app/models/letter.rb
+++ b/back/app/models/letter.rb
@@ -1,0 +1,2 @@
+class Letter < ApplicationRecord
+end

--- a/back/app/models/post.rb
+++ b/back/app/models/post.rb
@@ -1,0 +1,2 @@
+class Post < ApplicationRecord
+end

--- a/back/app/models/post_genre.rb
+++ b/back/app/models/post_genre.rb
@@ -1,0 +1,2 @@
+class PostGenre < ApplicationRecord
+end

--- a/back/app/models/post_letter.rb
+++ b/back/app/models/post_letter.rb
@@ -1,0 +1,2 @@
+class PostLetter < ApplicationRecord
+end

--- a/back/app/models/post_tag.rb
+++ b/back/app/models/post_tag.rb
@@ -1,0 +1,2 @@
+class PostTag < ApplicationRecord
+end

--- a/back/app/models/tag.rb
+++ b/back/app/models/tag.rb
@@ -1,0 +1,2 @@
+class Tag < ApplicationRecord
+end

--- a/back/db/migrate/20240610090201_create_posts.rb
+++ b/back/db/migrate/20240610090201_create_posts.rb
@@ -1,0 +1,9 @@
+class CreatePosts < ActiveRecord::Migration[7.1]
+  def change
+    create_table :posts do |t|
+      t.string :uuid, :null => false, :default => "UUID()"
+      t.timestamps
+    end
+    add_index :posts, :uuid, :unique => true
+  end
+end

--- a/back/db/migrate/20240610090211_create_letters.rb
+++ b/back/db/migrate/20240610090211_create_letters.rb
@@ -1,0 +1,13 @@
+class CreateLetters < ActiveRecord::Migration[7.1]
+  def change
+    create_table :letters do |t|
+      t.string :uuid, :null => false, :default => "UUID()"
+      t.text :sentences, :null => false, :limit => 100000
+      t.string :name, :null => false, :limit => 10
+      t.references :post, :null => false, :default => 0
+      t.references :user, :null => false, :default => 0
+      t.timestamps
+    end
+    add_index :letters, :uuid, :unique => true
+  end
+end

--- a/back/db/migrate/20240610090226_create_post_letters.rb
+++ b/back/db/migrate/20240610090226_create_post_letters.rb
@@ -1,0 +1,8 @@
+class CreatePostLetters < ActiveRecord::Migration[7.1]
+  def change
+    create_table :post_letters do |t|
+      t.references :post, :null => false
+      t.references :letter, :null => false
+    end
+  end
+end

--- a/back/db/migrate/20240610090240_create_genres.rb
+++ b/back/db/migrate/20240610090240_create_genres.rb
@@ -1,0 +1,9 @@
+class CreateGenres < ActiveRecord::Migration[7.1]
+  def change
+    create_table :genres do |t|
+      t.string :name, :null => false, :limit => 10
+      t.timestamps
+    end
+    add_index :genres, :name, :unique => true
+  end
+end

--- a/back/db/migrate/20240610090246_create_post_genres.rb
+++ b/back/db/migrate/20240610090246_create_post_genres.rb
@@ -1,0 +1,8 @@
+class CreatePostGenres < ActiveRecord::Migration[7.1]
+  def change
+    create_table :post_genres do |t|
+      t.references :post, :null => false
+      t.references :genre, :null => false
+    end
+  end
+end

--- a/back/db/migrate/20240610090253_create_tags.rb
+++ b/back/db/migrate/20240610090253_create_tags.rb
@@ -1,0 +1,9 @@
+class CreateTags < ActiveRecord::Migration[7.1]
+  def change
+    create_table :tags do |t|
+      t.string :name, :null => false, :limit => 10
+      t.timestamps
+    end
+    add_index :tags, :name, :unique => true
+  end
+end

--- a/back/db/migrate/20240610090303_create_post_tags.rb
+++ b/back/db/migrate/20240610090303_create_post_tags.rb
@@ -1,0 +1,8 @@
+class CreatePostTags < ActiveRecord::Migration[7.1]
+  def change
+    create_table :post_tags do |t|
+      t.references :post, :null => false
+      t.references :tag, :null => false
+    end
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,62 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_08_070210) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_10_090303) do
+  create_table "genres", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", limit: 10, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_genres_on_name", unique: true
+  end
+
+  create_table "letters", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "uuid", default: "UUID()", null: false
+    t.text "sentences", size: :medium, null: false
+    t.string "name", limit: 10, null: false
+    t.bigint "post_id", default: 0, null: false
+    t.bigint "user_id", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_letters_on_post_id"
+    t.index ["user_id"], name: "index_letters_on_user_id"
+    t.index ["uuid"], name: "index_letters_on_uuid", unique: true
+  end
+
+  create_table "post_genres", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "post_id", null: false
+    t.bigint "genre_id", null: false
+    t.index ["genre_id"], name: "index_post_genres_on_genre_id"
+    t.index ["post_id"], name: "index_post_genres_on_post_id"
+  end
+
+  create_table "post_letters", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "post_id", null: false
+    t.bigint "letter_id", null: false
+    t.index ["letter_id"], name: "index_post_letters_on_letter_id"
+    t.index ["post_id"], name: "index_post_letters_on_post_id"
+  end
+
+  create_table "post_tags", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "post_id", null: false
+    t.bigint "tag_id", null: false
+    t.index ["post_id"], name: "index_post_tags_on_post_id"
+    t.index ["tag_id"], name: "index_post_tags_on_tag_id"
+  end
+
+  create_table "posts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "uuid", default: "UUID()", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["uuid"], name: "index_posts_on_uuid", unique: true
+  end
+
+  create_table "tags", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", limit: 10, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_tags_on_name", unique: true
+  end
+
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "provider", default: "google_oauth2", null: false
     t.string "uid", default: "", null: false


### PR DESCRIPTION
## 概要
投稿周りの関連テーブルをマイグレーションしました

## 紐づく issue
close #6 

## チェック項目
- [x] posts
   - [ ] id：uuid型、デフォルトはランダムなuuidを短縮して付与
   - [x] uuid：uuid型、null false、ユニーク属性
   - [x] タイムスタンプ：中間テーブルや子テーブルが更新されたら更新日時が更新されること
- [x] post_letters
   - [x] post_id：uuid型
   - [x] letter_id：uuid型
- [x] letters
   - [ ] id：uuid型
   - [x] uuid：uuid型、null false、ユニーク属性
   - [x] sentences：100000文字のバリデーション
   - [x] name：10文字のバリデーション
   - [x] user_id：uuid型 ⇨ 通常のデータ型
   - [x] post_id：uuid型 ⇨ 通常のデータ型
- [x] post_genres
   - [x] post_id：uuid型 ⇨ 通常のデータ型
   - [x] genre_id
- [x] genres
   - [x] id
   - [x] name：10文字のバリデーション、ユニーク属性
- [x] post_tags
   - [x] post_id：uuid型 ⇨ 通常のデータ型
   - [x] tag_id
- [x] tag
   - [x] id
   - [x] name：10文字のバリデーション、ユニーク属性

### 未実装の項目
下記はアソシエーションでの生成などで不具合が生じるのでなしにしました。
- posts
   - [ ] id：uuid型、デフォルトはランダムなuuidを短縮して付与
- letters
   - [ ] id：uuid型
- post_genres
   - [ ] post_id：uuid型
- post_tags
   - [ ] post_id：uuid型

## 挙動
なし

## 補足
なし

## 参考
なし