### PR TITLE
【feature】アソシエーション設定 close #7

### DIFF
--- a/back/app/models/genre.rb
+++ b/back/app/models/genre.rb
@@ -1,2 +1,5 @@
 class Genre < ApplicationRecord
+  has_many :post_genres, dependent: :destroy
+  has_many :posts, through: :post_genres, source: :post
+  validates :name, presence: true, length: { maximum: 10 }
 end

--- a/back/app/models/letter.rb
+++ b/back/app/models/letter.rb
@@ -1,2 +1,7 @@
 class Letter < ApplicationRecord
+  has_many :post_letters, dependent: :destroy
+  has_many :posts, through: :post_letters, source: :post
+  belongs_to :user
+  validates :sentences, presence: true, length: { maximum: 100_000 }
+  validates :name, presence: true, length: { maximum: 10 }, defaults: { name: '名もなき人' }
 end

--- a/back/app/models/post.rb
+++ b/back/app/models/post.rb
@@ -1,2 +1,8 @@
 class Post < ApplicationRecord
+  has_many :post_letters, dependent: :destroy
+  has_many :letters, through: :post_letters, source: :letter
+  has_many :post_genres, dependent: :destroy
+  has_many :genres, through: :post_genres, source: :genre
+  has_many :post_tags, dependent: :destroy
+  has_many :tags, through: :post_tags, source: :tag
 end

--- a/back/app/models/post_genre.rb
+++ b/back/app/models/post_genre.rb
@@ -1,2 +1,4 @@
 class PostGenre < ApplicationRecord
+  belongs_to :post
+  belongs_to :genre
 end

--- a/back/app/models/post_letter.rb
+++ b/back/app/models/post_letter.rb
@@ -1,2 +1,4 @@
 class PostLetter < ApplicationRecord
+  belongs_to :post
+  belongs_to :letter
 end

--- a/back/app/models/post_tag.rb
+++ b/back/app/models/post_tag.rb
@@ -1,2 +1,4 @@
 class PostTag < ApplicationRecord
+  belongs_to :post
+  belongs_to :tag
 end

--- a/back/app/models/tag.rb
+++ b/back/app/models/tag.rb
@@ -1,2 +1,5 @@
 class Tag < ApplicationRecord
+  has_many :post_tags, dependent: :destroy
+  has_many :posts, through: :post_tags, source: :post
+  validates :name, presence: true, length: { maximum: 10 }
 end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -5,6 +5,8 @@ class User < ActiveRecord::Base
   devise :omniauthable, omniauth_providers: %i[google_oauth2]
   include DeviseTokenAuth::Concerns::User
 
+  has_many :letters, dependent: :destroy
+
   def self.find_or_create_by_oauth(auth)
     transaction do
       user = find_by(uid: auth.uid)


### PR DESCRIPTION
## 概要
投稿関連にアソシエーションとバリデーションを設定しました。

## 紐づく issue
close #7 

## チェック項目
- [x] Post
   - [x] post_letters：アソシエーション
   - [x] letters：アソシエーション（中間テーブルはpost_letters）
   - [x] post_genres：アソシエーション
   - [x] genres：アソシエーション（中間テーブルはpost_letters）
   - [x] post_tags：アソシエーション
   - [x] tags：アソシエーション（中間テーブルはpost_tags）
- [x] PostLetter
   - [x] post_letters：アソシエーション
   - [x] letters：アソシエーション（中間テーブルはpost_letters）
- [x] Letter
   - [x] sentences：100000文字のバリデーション
   - [x] name：10文字のバリデーション
   - [x] user：アソシエーション
   - [x] post_letters：アソシエーション
   - [x] posts：アソシエーション（中間テーブルはpost_letters）
- [ ] PostGenre
   - [ ] post：アソシエーション
   - [ ] genre：アソシエーション
- [x] Genre
   - [x] name：10文字のバリデーション
   - [x] post_genre：アソシエーション
   - [x] posts：アソシエーション（中間テーブルはpost_genre）
- [x] PostTag
   - [x] post：アソシエーション
   - [x] tag：アソシエーション
- [x] Tag
   - [x] name：10文字のバリデーション
   - [x] post_tag：アソシエーション
   - [x] posts：アソシエーション（中間テーブルはpost_tag）
- [x] User
   - [x] letters：アソシエーション

### 未実装の項目

## 挙動
なし

## 補足
なし

## 参考
なし