### PR TITLE
【feature】メインレイアウトの作成 resolve #22

### DIFF
--- a/front/.eslintignore
+++ b/front/.eslintignore
@@ -6,6 +6,7 @@ next.config.js
 tailwind.config.js
 tsconfig.json
 postcss.config.js
+next.config.mjs
 
 # build dir
 build/

--- a/front/.eslintrc.json
+++ b/front/.eslintrc.json
@@ -2,7 +2,6 @@
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
-    "plugin:@typescript-eslint/recommended-requiring-type-checking",
     "next/core-web-vitals",
     "prettier"
   ],

--- a/front/package.json
+++ b/front/package.json
@@ -11,12 +11,14 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "@next/font": "^14.2.3",
     "@types/js-cookie": "^3.0.6",
     "@typescript-eslint/eslint-plugin": "^7.12.0",
     "@typescript-eslint/parser": "^7.12.0",
     "axios": "^1.7.2",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-import": "^2.29.1",
+    "framer-motion": "^11.2.10",
     "husky": "^9.0.11",
     "js-cookie": "^3.0.5",
     "lint-staged": "^15.2.5",

--- a/front/src/app/globals.css
+++ b/front/src/app/globals.css
@@ -2,6 +2,28 @@
 @tailwind components;
 @tailwind utilities;
 
+
+/* ================================== */
+/*            GoogleFonts             */
+/* ================================== */
+.lxgw-wenkai-tc-light {
+  font-family: "LXGW WenKai TC", cursive;
+  font-weight: 300;
+  font-style: normal;
+}
+
+.lxgw-wenkai-tc-regular {
+  font-family: "LXGW WenKai TC", cursive;
+  font-weight: 400;
+  font-style: normal;
+}
+
+.lxgw-wenkai-tc-bold {
+  font-family: "LXGW WenKai TC", cursive;
+  font-weight: 700;
+  font-style: normal;
+}
+
 /* ================================== */
 /*        Googleログインボタン        */
 /* ================================== */

--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -1,5 +1,7 @@
-import type { Metadata } from "next";
 import "./globals.css";
+import * as Layouts from "@/components/layouts";
+
+import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "言の葉つづり",
@@ -13,7 +15,17 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja">
-      <body>{children}</body>
+      <head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=LXGW+WenKai+TC:wght@300;400;700&display=swap"
+          rel="stylesheet"
+        />
+      </head>
+      <body>
+        <Layouts.MainLayout>{children}</Layouts.MainLayout>
+      </body>
     </html>
   );
 }

--- a/front/src/app/login/page.tsx
+++ b/front/src/app/login/page.tsx
@@ -39,7 +39,6 @@ export default function Login() {
   useEffect(() => {
     if (!isLogged) return;
     const tokens = Lib.getToken();
-    console.log(tokens.accessToken, tokens.uid, tokens.expiry, tokens.client);
     if (tokens.accessToken && tokens.uid && tokens.expiry && tokens.client) {
       router.push(Config.Routes.home);
       return;

--- a/front/src/app/logout/page.tsx
+++ b/front/src/app/logout/page.tsx
@@ -1,0 +1,8 @@
+export default function Logout() {
+  return (
+    <article>
+      <h1>ばいばいする？</h1>
+      <section></section>
+    </article>
+  );
+}

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -1,9 +1,7 @@
 export default function Home() {
   return (
     <article>
-      <section>
-        <h1>言の葉つづり</h1>
-      </section>
+      <section></section>
     </article>
   );
 }

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -1,7 +1,3 @@
 export default function Home() {
-  return (
-    <article>
-      <section></section>
-    </article>
-  );
+  return <></>;
 }

--- a/front/src/components/layouts/footers/index.tsx
+++ b/front/src/components/layouts/footers/index.tsx
@@ -1,0 +1,22 @@
+import Link from "next/link";
+
+export default function Footers() {
+  return (
+    <div className="flex flex-col items-center justify-between gap-2 bg-slate-100 py-2">
+      <h5>言の葉つづり</h5>
+      <ul className="flex gap-2 text-sm">
+        <li>
+          <Link href="#" className="text-sky-300">
+            利用規約
+          </Link>
+        </li>
+        <li>
+          <Link href="#" className="text-sky-300">
+            プライバシーポリシー
+          </Link>
+        </li>
+      </ul>
+      <small>©2024 言の葉つづり</small>
+    </div>
+  );
+}

--- a/front/src/components/layouts/footers/index.tsx
+++ b/front/src/components/layouts/footers/index.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 export default function Footers() {
   return (
-    <div className="flex flex-col items-center justify-between gap-2 bg-slate-100 py-2">
+    <div className="flex flex-col items-center justify-between gap-2 border-t border-dashed border-sky-300 bg-slate-100 py-2">
       <h5>言の葉つづり</h5>
       <ul className="flex gap-2 text-sm">
         <li>

--- a/front/src/components/layouts/headers/index.tsx
+++ b/front/src/components/layouts/headers/index.tsx
@@ -1,17 +1,15 @@
 "use client";
 import * as Motion from "framer-motion";
 import Link from "next/link";
-import { useRef, useState } from "react";
+import { useState } from "react";
 
+import { Top } from "@/components/layouts";
 import * as UI from "@/components/ui";
 import { Routes } from "@/config";
-import * as Hook from "@/hooks";
 
 export default function Headers() {
   const [isOpen, toggleOpen] = Motion.useCycle(false, true);
-  const [isVisible, setIsVisible] = useState(true);
-  const containerRef = useRef(null);
-  const { height } = Hook.useDimensions(containerRef);
+  const [isVisible, setIsVisible] = useState(false);
 
   const handleToggle = () => {
     if (isOpen) {
@@ -29,21 +27,22 @@ export default function Headers() {
   };
 
   return (
-    <div className="relative w-full">
-      <h1 className="border-b border-dashed border-sky-300 bg-white py-2 text-center text-2xl md:py-6">
-        <Link href={Routes.home}>言の葉つづり</Link>
-      </h1>
-      <Motion.motion.nav
-        id="menu"
-        animate={isOpen ? "open" : "closed"}
-        custom={height}
-        ref={containerRef}
-        className={isOpen ? "absolute left-0 top-0 z-50 w-full bg-black bg-opacity-40" : ""}
-        onAnimationComplete={handleAnimationComplete}
-      >
-        <UI.NavigationMenu isVisible={isVisible} handleToggle={handleToggle} />
-        <UI.NavigationMenuToggle isOpen={isOpen} toggle={handleToggle} />
-      </Motion.motion.nav>
-    </div>
+    <>
+      <div className="relative w-full">
+        <h1 className="border-b border-dashed border-sky-300 bg-white py-2 text-center text-2xl md:py-6">
+          <Link href={Routes.home}>言の葉つづり</Link>
+        </h1>
+        <Motion.motion.nav
+          id="menu"
+          animate={isOpen ? "open" : "closed"}
+          className={isOpen ? "absolute left-0 top-0 z-50 w-full bg-black bg-opacity-40" : ""}
+          onAnimationComplete={handleAnimationComplete}
+        >
+          <UI.NavigationMenu isVisible={isVisible} handleToggle={handleToggle} />
+          <UI.NavigationMenuToggle isOpen={isOpen} toggle={handleToggle} />
+        </Motion.motion.nav>
+      </div>
+      <Top />
+    </>
   );
 }

--- a/front/src/components/layouts/headers/index.tsx
+++ b/front/src/components/layouts/headers/index.tsx
@@ -1,0 +1,45 @@
+"use client";
+import * as Motion from "framer-motion";
+import { useRef, useState } from "react";
+
+import * as UI from "@/components/ui";
+import * as Hook from "@/hooks";
+
+export default function Headers() {
+  const [isOpen, toggleOpen] = Motion.useCycle(false, true);
+  const [isVisible, setIsVisible] = useState(true);
+  const containerRef = useRef(null);
+  const { height } = Hook.useDimensions(containerRef);
+
+  const handleToggle = () => {
+    if (isOpen) {
+      toggleOpen();
+    } else {
+      setIsVisible(true);
+      toggleOpen();
+    }
+  };
+
+  const handleAnimationComplete = () => {
+    if (!isOpen) {
+      setIsVisible(false);
+    }
+  };
+
+  return (
+    <div className="w-full">
+      <h1>言の葉つづり</h1>
+      <Motion.motion.nav
+        id="menu"
+        animate={isOpen ? "open" : "closed"}
+        custom={height}
+        ref={containerRef}
+        className={isOpen ? "fixed left-0 top-0 z-50 h-full w-full bg-black bg-opacity-40" : ""}
+        onAnimationComplete={handleAnimationComplete}
+      >
+        <UI.NavigationMenu isVisible={isVisible} handleToggle={handleToggle} />
+        <UI.NavigationMenuToggle isOpen={isOpen} toggle={handleToggle} />
+      </Motion.motion.nav>
+    </div>
+  );
+}

--- a/front/src/components/layouts/headers/index.tsx
+++ b/front/src/components/layouts/headers/index.tsx
@@ -1,8 +1,10 @@
 "use client";
 import * as Motion from "framer-motion";
+import Link from "next/link";
 import { useRef, useState } from "react";
 
 import * as UI from "@/components/ui";
+import { Routes } from "@/config";
 import * as Hook from "@/hooks";
 
 export default function Headers() {
@@ -27,14 +29,16 @@ export default function Headers() {
   };
 
   return (
-    <div className="w-full">
-      <h1>言の葉つづり</h1>
+    <div className="relative w-full">
+      <h1 className="border-b border-dashed border-sky-300 bg-white py-2 text-center text-2xl md:py-6">
+        <Link href={Routes.home}>言の葉つづり</Link>
+      </h1>
       <Motion.motion.nav
         id="menu"
         animate={isOpen ? "open" : "closed"}
         custom={height}
         ref={containerRef}
-        className={isOpen ? "fixed left-0 top-0 z-50 h-full w-full bg-black bg-opacity-40" : ""}
+        className={isOpen ? "absolute left-0 top-0 z-50 w-full bg-black bg-opacity-40" : ""}
         onAnimationComplete={handleAnimationComplete}
       >
         <UI.NavigationMenu isVisible={isVisible} handleToggle={handleToggle} />

--- a/front/src/components/layouts/index.ts
+++ b/front/src/components/layouts/index.ts
@@ -1,5 +1,6 @@
 import Footers from "./footers";
 import Headers from "./headers";
 import MainLayout from "./mainLayout";
+import Top from "./top";
 
-export { Headers, Footers, MainLayout };
+export { Headers, Footers, MainLayout, Top };

--- a/front/src/components/layouts/index.ts
+++ b/front/src/components/layouts/index.ts
@@ -1,0 +1,5 @@
+import Footers from "./footers";
+import Headers from "./headers";
+import MainLayout from "./mainLayout";
+
+export { Headers, Footers, MainLayout };

--- a/front/src/components/layouts/mainLayout/index.tsx
+++ b/front/src/components/layouts/mainLayout/index.tsx
@@ -1,0 +1,15 @@
+import * as Layout from "@/components/layouts";
+
+export default function MainLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="lxgw-wenkai-tc-regular flex min-h-screen flex-col bg-sky-100">
+      <header>
+        <Layout.Headers />
+      </header>
+      <main className="flex-grow">{children}</main>
+      <footer>
+        <Layout.Footers />
+      </footer>
+    </div>
+  );
+}

--- a/front/src/components/layouts/mainLayout/index.tsx
+++ b/front/src/components/layouts/mainLayout/index.tsx
@@ -6,7 +6,7 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
       <header>
         <Layout.Headers />
       </header>
-      <main className="flex-grow">{children}</main>
+      <main className="mx-8 my-4 flex-grow">{children}</main>
       <footer>
         <Layout.Footers />
       </footer>

--- a/front/src/components/layouts/top/index.tsx
+++ b/front/src/components/layouts/top/index.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import * as Motion from "framer-motion";
+import { useState } from "react";
+
+const variantsH1 = {
+  openTop: {
+    y: -1000,
+    transition: {
+      y: { stiffness: 1000, duration: 1.5, ease: "easeInOut" },
+    },
+  },
+  closedTop: {
+    y: 0,
+    transition: {
+      y: { stiffness: 1000, duration: 1.5, ease: "easeInOut" },
+    },
+  },
+};
+
+const variantsButton = {
+  openTop: {
+    y: 1000,
+    transition: {
+      y: { stiffness: 1000, duration: 1.5, ease: "easeInOut" },
+    },
+  },
+  closedTop: {
+    y: 0,
+    transition: {
+      y: { stiffness: 1000, duration: 1.5, ease: "easeInOut" },
+    },
+  },
+};
+
+export default function Top() {
+  const [isOpen, toggleOpen] = Motion.useCycle(false, true);
+  const [isVisible, setIsVisible] = useState(true);
+
+  const handleToggle = () => {
+    if (isOpen) {
+      toggleOpen();
+    } else {
+      setIsVisible(true);
+      toggleOpen();
+    }
+  };
+
+  const handleAnimationComplete = () => {
+    if (isOpen) {
+      setIsVisible(false);
+    }
+  };
+
+  return (
+    <Motion.motion.article
+      className={`fixed left-0 top-0 z-50 h-full min-h-screen w-full ${isVisible ? "" : "hidden"}`}
+    >
+      <Motion.motion.h1
+        variants={variantsH1}
+        initial="closedTop"
+        animate={isOpen ? "openTop" : "closedTop"}
+        className="flex h-1/2 w-full items-end justify-center border-b border-dashed border-sky-300 bg-white pb-4 text-3xl"
+        onAnimationComplete={handleAnimationComplete}
+      >
+        言の葉つづり
+      </Motion.motion.h1>
+      <Motion.motion.button
+        variants={variantsButton}
+        initial="closedTop"
+        animate={isOpen ? "openTop" : "closedTop"}
+        className="flex h-1/2 w-full items-start justify-center border-t border-dashed border-sky-300 bg-white pt-4"
+        onAnimationComplete={handleAnimationComplete}
+        onClick={handleToggle}
+      >
+        手紙を開く
+      </Motion.motion.button>
+    </Motion.motion.article>
+  );
+}

--- a/front/src/components/ui/index.ts
+++ b/front/src/components/ui/index.ts
@@ -1,0 +1,5 @@
+import { NavigationMenu } from "./navigationMenu";
+import { NavigationMenuItem } from "./navigationMenuItem";
+import { NavigationMenuToggle } from "./navigationMenuToggle";
+
+export { NavigationMenu, NavigationMenuItem, NavigationMenuToggle };

--- a/front/src/components/ui/navigationMenu/index.tsx
+++ b/front/src/components/ui/navigationMenu/index.tsx
@@ -24,28 +24,28 @@ const divVariants = {
   },
 };
 
-const menuItems = [
-  {
+const menuItems = {
+  login: {
     href: Routes.login,
     word: "はろーわーるど",
   },
-  {
+  newPost: {
     href: Routes.newPost,
     word: "手紙を綴る",
   },
-  {
+  posts: {
     href: Routes.posts,
     word: "届いた手紙",
   },
-  {
+  user: {
     href: Routes.user("1"),
     word: "綴った手紙",
   },
-  {
+  logout: {
     href: Routes.logout,
     word: "しーゆーわーるど",
   },
-];
+};
 
 export const NavigationMenu = ({
   isVisible,
@@ -80,14 +80,35 @@ export const NavigationMenu = ({
         variants={variants}
         className={`absolute flex w-full flex-col items-center justify-center bg-slate-200 py-4 ${isVisible ? "" : "hidden md:block"}`}
       >
-        {menuItems.map((item, i) => (
-          <NavigationMenuItem
-            key={i}
-            href={item.href}
-            word={item.word}
-            handleToggle={handleToggle}
-          />
-        ))}
+        <NavigationMenuItem
+          href={menuItems.login.href}
+          word={menuItems.login.word}
+          handleToggle={handleToggle}
+        />
+
+        <NavigationMenuItem
+          href={menuItems.newPost.href}
+          word={menuItems.newPost.word}
+          handleToggle={handleToggle}
+        />
+
+        <NavigationMenuItem
+          href={menuItems.posts.href}
+          word={menuItems.posts.word}
+          handleToggle={handleToggle}
+        />
+
+        <NavigationMenuItem
+          href={menuItems.user.href}
+          word={menuItems.user.word}
+          handleToggle={handleToggle}
+        />
+
+        <NavigationMenuItem
+          href={menuItems.logout.href}
+          word={menuItems.logout.word}
+          handleToggle={handleToggle}
+        />
       </motion.ul>
     </motion.div>
   );

--- a/front/src/components/ui/navigationMenu/index.tsx
+++ b/front/src/components/ui/navigationMenu/index.tsx
@@ -74,7 +74,7 @@ export const NavigationMenu = ({
     <motion.div
       id="menuDiv"
       variants={divVariants}
-      className="fixed left-0 top-0 flex h-full w-full cursor-default flex-col items-center justify-center"
+      className={`fixed left-0 top-0 flex h-full w-full cursor-default flex-col items-center justify-center bg-black bg-opacity-50 ${isVisible ? "" : "hidden"}`}
     >
       <motion.ul
         variants={variants}

--- a/front/src/components/ui/navigationMenu/index.tsx
+++ b/front/src/components/ui/navigationMenu/index.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { useEffect } from "react";
+
+import { NavigationMenuItem } from "@/components/ui";
+import { Routes } from "@/config";
+
+const variants = {
+  open: {
+    transition: { staggerChildren: 0.07, delayChildren: 0.2 },
+  },
+  closed: {
+    transition: { staggerChildren: 0.05, staggerDirection: -1 },
+  },
+};
+
+const divVariants = {
+  open: {
+    opacity: 1,
+  },
+  closed: {
+    opacity: 0,
+  },
+};
+
+const menuItems = [
+  {
+    href: Routes.login,
+    word: "はろーわーるど",
+  },
+  {
+    href: Routes.newPost,
+    word: "手紙を綴る",
+  },
+  {
+    href: Routes.posts,
+    word: "届いた手紙",
+  },
+  {
+    href: Routes.user("1"),
+    word: "綴った手紙",
+  },
+  {
+    href: Routes.logout,
+    word: "しーゆーわーるど",
+  },
+];
+
+export const NavigationMenu = ({
+  isVisible,
+  handleToggle,
+}: {
+  isVisible: boolean;
+  handleToggle: () => void;
+}) => {
+  useEffect(() => {
+    const menudiv = document.getElementById("menuDiv");
+    if (!menudiv) return;
+
+    function handleClick(e: Event) {
+      if (e.target === menudiv) {
+        handleToggle();
+      }
+    }
+
+    document.addEventListener("click", handleClick);
+    return () => {
+      document.removeEventListener("click", handleClick);
+    };
+  }, []);
+
+  return (
+    <motion.div
+      id="menuDiv"
+      variants={divVariants}
+      className="fixed left-0 top-0 flex h-full w-full cursor-default flex-col items-center justify-center"
+    >
+      <motion.ul
+        variants={variants}
+        className={`absolute flex w-full flex-col items-center justify-center bg-slate-200 py-4 ${isVisible ? "" : "hidden md:block"}`}
+      >
+        {menuItems.map((item, i) => (
+          <NavigationMenuItem
+            key={i}
+            href={item.href}
+            word={item.word}
+            handleToggle={handleToggle}
+          />
+        ))}
+      </motion.ul>
+    </motion.div>
+  );
+};

--- a/front/src/components/ui/navigationMenuItem/index.tsx
+++ b/front/src/components/ui/navigationMenuItem/index.tsx
@@ -1,0 +1,49 @@
+import { motion } from "framer-motion";
+import { useRouter } from "next/navigation";
+
+const variants = {
+  open: {
+    y: 0,
+    opacity: 1,
+    transition: {
+      y: { stiffness: 1000, velocity: -100 },
+    },
+  },
+  closed: {
+    y: 50,
+    opacity: 0,
+    transition: {
+      y: { stiffness: 1000 },
+    },
+  },
+};
+
+export const NavigationMenuItem = ({
+  href,
+  word,
+  handleToggle,
+}: {
+  href: string;
+  word: string;
+  handleToggle: () => void;
+}) => {
+  const router = useRouter();
+
+  const handleLink = () => {
+    handleToggle();
+    router.push(href);
+  };
+
+  return (
+    <motion.li
+      variants={variants}
+      whileHover={{ scale: 1.3 }}
+      whileTap={{ scaleY: 0.95 }}
+      className="border-sky-10 w-full border border-dashed bg-white text-center"
+    >
+      <button onClick={handleLink} className="block h-full w-full py-2">
+        {word}
+      </button>
+    </motion.li>
+  );
+};

--- a/front/src/components/ui/navigationMenuToggle/index.tsx
+++ b/front/src/components/ui/navigationMenuToggle/index.tsx
@@ -1,9 +1,7 @@
 import { SVGMotionProps, motion } from "framer-motion";
-import { JSX, RefAttributes } from "react";
+import { JSX } from "react";
 
-const Path = (
-  props: JSX.IntrinsicAttributes & SVGMotionProps<SVGPathElement> & RefAttributes<SVGPathElement>,
-) => (
+const Path = (props: SVGMotionProps<SVGPathElement> & JSX.IntrinsicElements["path"]) => (
   <motion.path fill="transparent" strokeWidth="3" stroke="white" strokeLinecap="round" {...props} />
 );
 
@@ -27,10 +25,9 @@ export const NavigationMenuToggle = ({
         animate={isOpen ? "open" : "closed"}
       />
       <Path
-        d="M 3 12 L 21 12"
         variants={{
-          closed: { opacity: 1 },
-          open: { opacity: 0 },
+          closed: { opacity: 1, d: "M 3 12 L 21 12" },
+          open: { opacity: 0, d: "M 3 12 L 21 12" },
         }}
         transition={{ duration: 0.1 }}
         animate={isOpen ? "open" : "closed"}

--- a/front/src/components/ui/navigationMenuToggle/index.tsx
+++ b/front/src/components/ui/navigationMenuToggle/index.tsx
@@ -1,0 +1,47 @@
+import { SVGMotionProps, motion } from "framer-motion";
+import { JSX, RefAttributes } from "react";
+
+const Path = (
+  props: JSX.IntrinsicAttributes & SVGMotionProps<SVGPathElement> & RefAttributes<SVGPathElement>,
+) => (
+  <motion.path fill="transparent" strokeWidth="3" stroke="white" strokeLinecap="round" {...props} />
+);
+
+export const NavigationMenuToggle = ({
+  isOpen,
+  toggle,
+}: {
+  isOpen: boolean;
+  toggle: () => void;
+}) => (
+  <button
+    onClick={toggle}
+    className="fixed bottom-0 right-0 m-4 flex items-center justify-center rounded-full bg-sky-300 p-2 md:bottom-auto md:top-0"
+  >
+    <svg width="30" height="30" viewBox="0 0 24 24">
+      <Path
+        variants={{
+          closed: { d: "M 3 6 L 21 6" },
+          open: { d: "M 6 18 L 18 6" },
+        }}
+        animate={isOpen ? "open" : "closed"}
+      />
+      <Path
+        d="M 3 12 L 21 12"
+        variants={{
+          closed: { opacity: 1 },
+          open: { opacity: 0 },
+        }}
+        transition={{ duration: 0.1 }}
+        animate={isOpen ? "open" : "closed"}
+      />
+      <Path
+        variants={{
+          closed: { d: "M 3 18 L 21 18" },
+          open: { d: "M 6 6 L 18 18" },
+        }}
+        animate={isOpen ? "open" : "closed"}
+      />
+    </svg>
+  </button>
+);

--- a/front/src/config/routesPath.ts
+++ b/front/src/config/routesPath.ts
@@ -1,9 +1,14 @@
 const Routes = {
   home: "/",
   login: "/login",
+  logout: "/logout",
   users: "/users",
   user: (id: string) => `/users/${id}`,
   authFailure: "/auth/failure",
+  posts: "/posts",
+  post: (id: string) => `/posts/${id}`,
+  newPost: "/posts/new",
+  reply: (id: string) => `/posts/${id}/reply`,
 };
 
 export default Routes;

--- a/front/src/hooks/index.ts
+++ b/front/src/hooks/index.ts
@@ -1,0 +1,3 @@
+import { useDimensions } from "./useDimensions";
+
+export { useDimensions };

--- a/front/src/hooks/useDimensions/index.tsx
+++ b/front/src/hooks/useDimensions/index.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { RefObject } from "react";
+
+export const useDimensions = (ref: RefObject<HTMLElement>) => {
+  const dimensions = useRef({ width: 0, height: 0 });
+
+  useEffect(() => {
+    if (!ref.current) return;
+    dimensions.current.width = ref.current.offsetWidth;
+    dimensions.current.height = ref.current.offsetHeight;
+  }, []);
+
+  return dimensions.current;
+};

--- a/front/worker/index.js
+++ b/front/worker/index.js
@@ -1,0 +1,1 @@
+self.__WB_DISABLE_DEV_LOGS=true

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -121,6 +121,11 @@
   dependencies:
     glob "10.3.10"
 
+"@next/font@^14.2.3":
+  version "14.2.3"
+  resolved "https://registry.yarnpkg.com/@next/font/-/font-14.2.3.tgz#7b2e868a960cbe089f825b2e1e09e2933a04b9dc"
+  integrity sha512-u35UstQmvl3Yrvv2MOi6RcXMH3xDtmWTXcvkYcC/vCZHLqj/5JQ5UyFRf5saDWxFlZIkEh8HCzwNGoiHIr1/NQ==
+
 "@next/swc-darwin-arm64@14.2.3":
   version "14.2.3"
   resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.3.tgz#db1a05eb88c0224089b815ad10ac128ec79c2cdb"
@@ -1358,6 +1363,13 @@ form-data@^4.0.0:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
+
+framer-motion@^11.2.10:
+  version "11.2.10"
+  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-11.2.10.tgz#c8671e33e8f8d4abbd95efd20d3b8a888f457ed7"
+  integrity sha512-/gr3PLZUVFCc86a9MqCUboVrALscrdluzTb3yew+2/qKBU8CX6nzs918/SRBRCqaPbx0TZP10CB6yFgK2C5cYQ==
+  dependencies:
+    tslib "^2.4.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## 概要
メインレイアウトを作成しました

## 紐づく issue
resolve #22

## チェック項目
- [ ] ヘッダー
   - [x] アプリロゴ：トップページへ遷移できる
   - [x] 投稿一覧への遷移ができる
   - [x] ユーザー一覧への遷移医ができる
   - [x] マイページ（自分のユーザーページ）へ遷移できる
   - [x] ログインページへ遷移できる
   - [x] ログアウトページへ遷移できる
   - [ ] アプリロゴがある
     ⇨ ロゴは言の葉つづりに倣い一旦無し。文字だけにしています。
- [x] フッター
   - [x] アプリ名（©）
   - [x] 利用規約へのリンク
   - [x] プライバシーポリシーへのリンク
- [x] ヘッダーとフッターの配置
- [x] メインコンテンツ部分の背景色
- [x] フォントが選定され実装されていること

### 未実装の項目
ユーザーの自動ログインの実装がまだのため、ユーザー情報を取得できていません。
よってログイン状況によるメニューの表示・非表示は未実装です

## 挙動
| PC | SP |
| --- | --- |
| <img src="https://i.gyazo.com/273bf959dddbdc0a2cf48b5dfdeaf82d.gif" width="430px" /> | <img src="https://i.gyazo.com/8bc5dc007a61d7b542fb2ae9fe84864d.gif" width="180px" /> |

## 補足
[Framer motion](https://www.framer.com/motion/)を利用したので導入しています。
Framer motionを利用するにあたり「型付けの強制」で実装スピードが非常に遅くなるため、ESLintから「型付けの強制」を外しております。
使用したGoogleフォントは「[LXGW WenKai TC](https://fonts.google.com/specimen/LXGW+WenKai+TC)」です。next/fontに入っていなかったようなのでheadタグでインポートしています。


## 参考
[Next.js 13×Tailwind @next/fontでGoogleFontsやローカルフォントを高速化してみる](https://zenn.dev/tsuyoshi/articles/894592ac677148)
