### PR TITLE
【feature】投稿画面の作成 close #9

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -11,6 +11,9 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "@mantine/core": "^7.10.1",
+    "@mantine/form": "^7.10.1",
+    "@mantine/hooks": "^7.10.1",
     "@next/font": "^14.2.3",
     "@types/js-cookie": "^3.0.6",
     "@typescript-eslint/eslint-plugin": "^7.12.0",

--- a/front/src/app/globals.css
+++ b/front/src/app/globals.css
@@ -178,3 +178,34 @@
 *:focus-visible {
   outline: none;
 }
+
+.mantine-TagsInput-pill {
+  background-color: transparent;
+  border-radius: 4px;
+  border: 1px solid #ff8800;
+  color: #ff8800;
+}
+
+.mantine-Pill-label {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* ================================== */
+/*                 UI                 */
+/* ================================== */
+.stripe-pattern {
+  position: relative;
+  background: repeating-linear-gradient(
+    -45deg,
+    rgba(165, 247, 253, 0.514),
+    rgba(165, 247, 253, 0.514) 10px,
+    #fff 0,
+    #fff 20px
+  );
+  border-left: 2px dotted rgba(0, 0, 0, 0.1);
+  border-right: 2px dotted rgba(0, 0, 0, 0.1);
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.2);
+  transform: translateX(-4px) translateY(3px) rotateZ(-5deg);
+}

--- a/front/src/app/globals.css
+++ b/front/src/app/globals.css
@@ -1,7 +1,7 @@
+@import "@mantine/core/styles.css";
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
 
 /* ================================== */
 /*            GoogleFonts             */
@@ -142,4 +142,39 @@
 .gsi-material-button:not(:disabled):hover .gsi-material-button-state {
   background-color: #001d35;
   opacity: 8%;
+}
+
+/* ================================== */
+/*            入力フォーム            */
+/* ================================== */
+.lined-textarea {
+  background-image: repeating-linear-gradient(
+      to bottom,
+      transparent,
+      transparent calc(1.5rem - 1px),
+      #bae6fd calc(1.5rem - 1px),
+      #bae6fd 1.5rem
+    ),
+    linear-gradient(
+      to right,
+      #bae6fd 0%,
+      #bae6fd 25%,
+      transparent 25%,
+      transparent 50%,
+      #bae6fd 50%,
+      #bae6fd 75%,
+      transparent 75%,
+      transparent 100%
+    );
+  background-size:
+    100% 1.5rem,
+    10px 1px;
+  background-repeat: repeat-y, repeat-x;
+  background-position:
+    0 0,
+    0 calc(1.5rem - 1px);
+}
+
+*:focus-visible {
+  outline: none;
 }

--- a/front/src/app/posts/new/page.tsx
+++ b/front/src/app/posts/new/page.tsx
@@ -1,81 +1,132 @@
 "use client";
 
-import * as Mantine from "@mantine/core";
-import { useState } from "react";
+import { useForm } from "@mantine/form";
+import { motion } from "framer-motion";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+import * as Form from "@/components/forms";
+import * as UI from "@/components/ui";
+import { Routes } from "@/config";
 
 const Genres = ["SF", "ファンタジー", "恋愛", "ホラー", "ミステリー", "サスペンス", "ポエム"];
 
 const Tags = ["涙腺崩壊", "意味怖", "ほのぼの", "切ない", "ハッピー", "感動", "笑い", "おもしろ"];
 
 export default function PostNew() {
-  const [nameLengh, setNameLength] = useState(0);
-  const [letterLength, setLetterLength] = useState(0);
-  const isNameLengthValid = nameLengh <= 10;
-  const isLetterLengthValid = letterLength <= 100000;
+  const [isPost, setIsPost] = useState(false);
+  const [isPostAnimationComplete, setIsPostAnimationComplete] = useState(false);
+  const [isPostComplete, setIsPostComplete] = useState(false);
+  const router = useRouter();
+  const MAX_NAME_LENGTH = 10;
+  const MAX_SENTENCE_LENGTH = 100000;
+  const form = useForm({
+    initialValues: {
+      name: "",
+      letter: "",
+      genres: [],
+      tags: [],
+    },
+    validate: {
+      name: (value: string) => {
+        if (value.length > MAX_NAME_LENGTH) {
+          return `名前は${MAX_NAME_LENGTH}文字以内がいいな`;
+        }
+      },
+      letter: (value: string) => {
+        if (value.length > MAX_SENTENCE_LENGTH) {
+          return `${MAX_SENTENCE_LENGTH}文字まで書けるよ`;
+        }
+        if (value.length === 0) {
+          return "まだ何も書かれていないよ";
+        }
+      },
+    },
+  });
 
-  const resizeTextArea = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setLetterLength(e.target.value.length);
-    e.target.style.height = "auto";
-    e.target.style.height = `${e.target.scrollHeight}px`;
+  useEffect(() => {
+    if (isPostComplete && isPostAnimationComplete) {
+      router.push(Routes.home);
+    }
+  }, [isPostComplete, isPostAnimationComplete]);
+
+  const togglePost = () => {
+    setIsPost(!isPost);
+  };
+
+  const handleSubmit = async () => {
+    togglePost();
+
+    try {
+      // TODO : 投稿処理をここに書く
+      setIsPostComplete(true);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const onAnimationComplete = () => {
+    if (!isPost) return;
+    form.reset();
+    setIsPostAnimationComplete(true);
   };
 
   return (
-    <article className="flex w-full flex-col items-center justify-center gap-4">
-      <h1 className="text-center text-xl">手紙を書いてみよう</h1>
-      <section className="w-full">
-        <div className="flex w-full overflow-hidden bg-white p-4">
-          <form className="flex w-full flex-col items-center justify-center">
-            <div className="m-0 flex w-full flex-col items-end justify-center border-b border-sky-200">
-              <div className="flex">
-                <input
-                  placeholder="◯◯"
-                  className={`w-full text-end focus:outline-none ${isNameLengthValid ? "" : "text-red-400"}`}
-                  onChange={(e) => setNameLength(e.target.value.length)}
+    <>
+      <motion.article
+        initial={{ opacity: 1 }}
+        animate={isPost ? { opacity: 0 } : { opacity: 1 }}
+        className={`m-auto flex w-full max-w-[800px] flex-col items-center justify-center gap-4 ${isPostAnimationComplete ? "hidden" : ""}`}
+      >
+        <h1 className="text-center text-xl">手紙を書いてみよう</h1>
+        <section className="w-full">
+          <div className="flex w-full overflow-hidden bg-white p-4">
+            <form
+              className="flex w-full flex-col items-center justify-center"
+              onSubmit={form.onSubmit(handleSubmit)}
+            >
+              <div className="mb-8 mt-4 w-full">
+                <Form.Textarea
+                  onChange={form.getInputProps("letter").onChange}
+                  value={form.getValues().letter}
                 />
-                へ
               </div>
-              <small className={`text-sm text-gray-500 ${isNameLengthValid ? "" : "text-red-400"}`}>
-                {nameLengh}/10文字
-              </small>
-            </div>
-            <div className="mb-8 mt-4 w-full">
-              <textarea
-                className="lined-textarea h-full w-full resize-none px-2 text-base focus:outline-none"
-                placeholder="拝啓..."
-                onChange={(e) => {
-                  resizeTextArea(e);
-                }}
-              />
-              <small
-                className={`block text-end text-sm text-gray-500 ${isLetterLengthValid ? "" : "text-red-400"}`}
-              >
-                {letterLength}/100000文字
-              </small>
-            </div>
-            <Mantine.TagsInput
-              label="ジャンル"
-              placeholder="SF、ファンタジー、恋愛、ホラー、ミステリー"
-              width="100%"
-              splitChars={["、", ","]}
-              variant="unstyled"
-              className="w-full border-t border-dashed border-sky-200 py-2"
-              data={Genres}
-            />
-            <Mantine.TagsInput
-              label="タグ"
-              placeholder="涙腺崩壊、意味怖、ほのぼの、切ない、ハッピー"
-              width="100%"
-              splitChars={["、", ","]}
-              variant="unstyled"
-              className="w-full border-t border-dashed border-sky-200 py-2"
-              data={Tags}
-            />
-            <div className="w-full border-t border-dashed border-sky-200 py-2 text-center">
-              <button className="inline-block rounded bg-sky-400 px-3 py-1 text-white">投函</button>
-            </div>
-          </form>
-        </div>
-      </section>
-    </article>
+
+              <div className="m-0 flex w-full flex-col items-end justify-center border-b border-sky-200">
+                <Form.Input
+                  onChange={form.getInputProps("name").onChange}
+                  value={form.getValues().name}
+                />
+              </div>
+              <div className="mt-2 w-full">
+                <Form.TagsInput
+                  label="ジャンル"
+                  placeholder="SF、ファンタジー、恋愛、ホラー、ミステリー"
+                  data={Genres}
+                  props={form.getInputProps("genres")}
+                />
+              </div>
+              <div className="mt-2 w-full">
+                <Form.TagsInput
+                  label="タグ"
+                  placeholder="涙腺崩壊、意味怖、ほのぼの、切ない、ハッピー"
+                  data={Tags}
+                  props={form.getInputProps("tags")}
+                />
+              </div>
+              <div className="mt-4 w-full text-center">
+                <Form.ValidError errorMsg={[form.errors.name, form.errors.letter]} />
+                <Form.Button labelName="投函" />
+              </div>
+            </form>
+          </div>
+        </section>
+      </motion.article>
+      <UI.PostDirection
+        name={form.getValues().name}
+        isPost={isPost}
+        onAnimationComplete={onAnimationComplete}
+      />
+    </>
   );
 }

--- a/front/src/app/posts/new/page.tsx
+++ b/front/src/app/posts/new/page.tsx
@@ -1,8 +1,80 @@
+"use client";
+
+import * as Mantine from "@mantine/core";
+import { useState } from "react";
+
+const Genres = ["SF", "ファンタジー", "恋愛", "ホラー", "ミステリー", "サスペンス", "ポエム"];
+
+const Tags = ["涙腺崩壊", "意味怖", "ほのぼの", "切ない", "ハッピー", "感動", "笑い", "おもしろ"];
+
 export default function PostNew() {
+  const [nameLengh, setNameLength] = useState(0);
+  const [letterLength, setLetterLength] = useState(0);
+  const isNameLengthValid = nameLengh <= 10;
+  const isLetterLengthValid = letterLength <= 100000;
+
+  const resizeTextArea = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setLetterLength(e.target.value.length);
+    e.target.style.height = "auto";
+    e.target.style.height = `${e.target.scrollHeight}px`;
+  };
+
   return (
-    <article>
-      <section>
-        <h1>投稿新規作成</h1>
+    <article className="flex w-full flex-col items-center justify-center gap-4">
+      <h1 className="text-center text-xl">手紙を書いてみよう</h1>
+      <section className="w-full">
+        <div className="flex w-full overflow-hidden bg-white p-4">
+          <form className="flex w-full flex-col items-center justify-center">
+            <div className="m-0 flex w-full flex-col items-end justify-center border-b border-sky-200">
+              <div className="flex">
+                <input
+                  placeholder="◯◯"
+                  className={`w-full text-end focus:outline-none ${isNameLengthValid ? "" : "text-red-400"}`}
+                  onChange={(e) => setNameLength(e.target.value.length)}
+                />
+                へ
+              </div>
+              <small className={`text-sm text-gray-500 ${isNameLengthValid ? "" : "text-red-400"}`}>
+                {nameLengh}/10文字
+              </small>
+            </div>
+            <div className="mb-8 mt-4 w-full">
+              <textarea
+                className="lined-textarea h-full w-full resize-none px-2 text-base focus:outline-none"
+                placeholder="拝啓..."
+                onChange={(e) => {
+                  resizeTextArea(e);
+                }}
+              />
+              <small
+                className={`block text-end text-sm text-gray-500 ${isLetterLengthValid ? "" : "text-red-400"}`}
+              >
+                {letterLength}/100000文字
+              </small>
+            </div>
+            <Mantine.TagsInput
+              label="ジャンル"
+              placeholder="SF、ファンタジー、恋愛、ホラー、ミステリー"
+              width="100%"
+              splitChars={["、", ","]}
+              variant="unstyled"
+              className="w-full border-t border-dashed border-sky-200 py-2"
+              data={Genres}
+            />
+            <Mantine.TagsInput
+              label="タグ"
+              placeholder="涙腺崩壊、意味怖、ほのぼの、切ない、ハッピー"
+              width="100%"
+              splitChars={["、", ","]}
+              variant="unstyled"
+              className="w-full border-t border-dashed border-sky-200 py-2"
+              data={Tags}
+            />
+            <div className="w-full border-t border-dashed border-sky-200 py-2 text-center">
+              <button className="inline-block rounded bg-sky-400 px-3 py-1 text-white">投函</button>
+            </div>
+          </form>
+        </div>
       </section>
     </article>
   );

--- a/front/src/components/forms/button/index.tsx
+++ b/front/src/components/forms/button/index.tsx
@@ -1,0 +1,18 @@
+export default function Button({
+  labelName,
+  className,
+  onClick,
+}: {
+  labelName: string;
+  className?: string;
+  onClick?: React.MouseEventHandler<HTMLButtonElement> | undefined;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`inline-block rounded bg-sky-400 px-3 py-1 text-white ${className}`}
+    >
+      {labelName}
+    </button>
+  );
+}

--- a/front/src/components/forms/index.ts
+++ b/front/src/components/forms/index.ts
@@ -1,0 +1,7 @@
+import Button from "./button";
+import Input from "./input";
+import TagsInput from "./tagsInput";
+import Textarea from "./textarea";
+import ValidError from "./validError";
+
+export { Input, Textarea, TagsInput, ValidError, Button };

--- a/front/src/components/forms/input/index.tsx
+++ b/front/src/components/forms/input/index.tsx
@@ -1,0 +1,29 @@
+export default function Input({
+  onChange,
+  value,
+}: {
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  value: string;
+}) {
+  const nameLength = value.length;
+  const isNameLengthValid = nameLength <= 10;
+  return (
+    <div className="relative flex w-full items-center justify-start">
+      <input
+        id="name"
+        placeholder="名もなき人"
+        name="name"
+        className={`w-2/3 max-w-[16rem] focus:outline-none ${isNameLengthValid ? "" : "text-red-400"}`}
+        onChange={onChange}
+      />
+      <div className="flex items-center justify-center">
+        <label htmlFor="name" className="shrink">
+          より
+        </label>
+        <p className={`shrink text-sm text-gray-500 ${isNameLengthValid ? "" : "text-red-400"}`}>
+          {nameLength}/10文字
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/front/src/components/forms/input/index.tsx
+++ b/front/src/components/forms/input/index.tsx
@@ -5,8 +5,9 @@ export default function Input({
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   value: string;
 }) {
+  const MAX_LENGTH = 10;
   const nameLength = value.length;
-  const isNameLengthValid = nameLength <= 10;
+  const isNameLengthValid = nameLength <= MAX_LENGTH;
   return (
     <div className="relative flex w-full items-center justify-start">
       <input
@@ -21,7 +22,7 @@ export default function Input({
           より
         </label>
         <p className={`shrink text-sm text-gray-500 ${isNameLengthValid ? "" : "text-red-400"}`}>
-          {nameLength}/10文字
+          {nameLength}/{MAX_LENGTH}文字
         </p>
       </div>
     </div>

--- a/front/src/components/forms/tagsInput/index.tsx
+++ b/front/src/components/forms/tagsInput/index.tsx
@@ -1,0 +1,29 @@
+import * as Mantine from "@mantine/core";
+
+export default function TagsInput({
+  label,
+  placeholder,
+  data,
+  props,
+}: {
+  label: string;
+  placeholder: string;
+  data: string[];
+  props: object;
+}) {
+  return (
+    <>
+      <Mantine.InputLabel className="stripe-pattern px-2">{label}</Mantine.InputLabel>
+      <Mantine.TagsInput
+        name="genres"
+        placeholder={placeholder}
+        width="100%"
+        splitChars={["、", ","]}
+        variant="unstyled"
+        className="border-b border-dashed border-sky-200"
+        {...props}
+        data={data}
+      />
+    </>
+  );
+}

--- a/front/src/components/forms/textarea/index.tsx
+++ b/front/src/components/forms/textarea/index.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+export default function Textarea({
+  onChange,
+  value,
+}: {
+  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  value: string;
+}) {
+  const MAX_LENGTH = 100000;
+  const letterLength = value.length;
+  const isLetterLengthValid = letterLength <= MAX_LENGTH;
+
+  const resizeTextArea = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    e.target.style.height = "auto";
+    e.target.style.height = `${e.target.scrollHeight}px`;
+  };
+
+  return (
+    <>
+      <textarea
+        className={`lined-textarea h-full w-full resize-none px-2 text-base focus:outline-none ${isLetterLengthValid ? "" : "text-red-400"}`}
+        placeholder="拝啓..."
+        value={value}
+        onChange={(e) => {
+          resizeTextArea(e);
+          onChange(e);
+        }}
+      />
+      <small
+        className={`block text-end text-sm text-gray-500 ${isLetterLengthValid ? "" : "text-red-400"}`}
+      >
+        {letterLength}/100000文字
+      </small>
+    </>
+  );
+}

--- a/front/src/components/forms/textarea/index.tsx
+++ b/front/src/components/forms/textarea/index.tsx
@@ -30,7 +30,7 @@ export default function Textarea({
       <small
         className={`block text-end text-sm text-gray-500 ${isLetterLengthValid ? "" : "text-red-400"}`}
       >
-        {letterLength}/100000文字
+        {letterLength}/{MAX_LENGTH}文字
       </small>
     </>
   );

--- a/front/src/components/forms/validError/index.tsx
+++ b/front/src/components/forms/validError/index.tsx
@@ -1,0 +1,7 @@
+export default function ValidError({ errorMsg }: { errorMsg: React.ReactNode[] }) {
+  return (
+    <div className="text-sm text-red-400">
+      {errorMsg.map((msg: React.ReactNode, index: number) => msg && <div key={index}>{msg}</div>)}
+    </div>
+  );
+}

--- a/front/src/components/layouts/mainLayout/index.tsx
+++ b/front/src/components/layouts/mainLayout/index.tsx
@@ -1,15 +1,19 @@
+import { MantineProvider } from "@mantine/core";
+
 import * as Layout from "@/components/layouts";
 
 export default function MainLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="lxgw-wenkai-tc-regular flex min-h-screen flex-col bg-sky-100">
-      <header>
-        <Layout.Headers />
-      </header>
-      <main className="mx-8 my-4 flex-grow">{children}</main>
-      <footer>
-        <Layout.Footers />
-      </footer>
+      <MantineProvider>
+        <header>
+          <Layout.Headers />
+        </header>
+        <main className="mx-4 my-4 flex-grow">{children}</main>
+        <footer>
+          <Layout.Footers />
+        </footer>
+      </MantineProvider>
     </div>
   );
 }

--- a/front/src/components/ui/index.ts
+++ b/front/src/components/ui/index.ts
@@ -1,5 +1,6 @@
 import { NavigationMenu } from "./navigationMenu";
 import { NavigationMenuItem } from "./navigationMenuItem";
 import { NavigationMenuToggle } from "./navigationMenuToggle";
+import PostDirection from "./postDirection";
 
-export { NavigationMenu, NavigationMenuItem, NavigationMenuToggle };
+export { NavigationMenu, NavigationMenuItem, NavigationMenuToggle, PostDirection };

--- a/front/src/components/ui/postDirection/index.tsx
+++ b/front/src/components/ui/postDirection/index.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { motion, useAnimation } from "framer-motion";
+import { useEffect } from "react";
+
+const variants = {
+  initial: {
+    backgroundColor: "rgba(255, 255, 255, 0)",
+    scale: 1,
+    rotate: 0,
+    opacity: 0,
+    y: 0,
+  },
+  fullScreenWhite: {
+    backgroundColor: "rgba(255, 255, 255, 1)",
+    scale: 1,
+    rotate: 0,
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.2 },
+  },
+  shrinkRotate: {
+    scale: 0.5,
+    rotate: -45,
+    transition: { duration: 0.5 },
+  },
+  showText: {
+    opacity: 1,
+    transition: { duration: 0.5 },
+  },
+  moveUp: {
+    y: -200,
+    opacity: 0,
+    transition: { duration: 0.5 },
+  },
+};
+
+export default function PostDirection({
+  name,
+  isPost,
+  onAnimationComplete,
+}: {
+  name: string;
+  isPost: boolean;
+  onAnimationComplete: () => void;
+}) {
+  const controls = useAnimation();
+
+  useEffect(() => {
+    const sequence = async () => {
+      await controls.start("fullScreenWhite");
+      await controls.start("shrinkRotate");
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      await controls.start("showText");
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      await controls.start("moveUp");
+      onAnimationComplete();
+    };
+
+    if (isPost) {
+      sequence();
+    }
+  }, [isPost]);
+
+  return (
+    <div className={`fixed left-0 top-0 h-full w-full ${isPost ? "" : "hidden"}`}>
+      <motion.div
+        variants={variants}
+        initial="initial"
+        animate={controls}
+        style={{
+          width: "100%",
+          height: "100%",
+          position: "relative",
+          maxWidth: "1200px",
+          maxHeight: "80%",
+          margin: "auto",
+        }}
+      >
+        <motion.div
+          initial={{ opacity: 0 }}
+          style={{
+            position: "absolute",
+            top: "50%",
+            left: "50%",
+            transform: "translate(-50%, -50%) rotate(90deg)",
+            color: "black",
+            fontSize: "3rem",
+            textAlign: "center",
+            whiteSpace: "nowrap",
+          }}
+          variants={{
+            showText: { opacity: 1, transition: { duration: 0.5 } },
+          }}
+        >
+          {name.length > 0 ? name : "名もなき人"} より
+        </motion.div>
+      </motion.div>
+    </div>
+  );
+}

--- a/front/src/features/posts/index.ts
+++ b/front/src/features/posts/index.ts
@@ -1,0 +1,3 @@
+import NewPost from "./newPost";
+
+export { NewPost };

--- a/front/src/features/posts/newPost/index.tsx
+++ b/front/src/features/posts/newPost/index.tsx
@@ -1,0 +1,14 @@
+import { axiosClient } from "@/lib";
+
+export default async function NewPost(value: string) {
+  try {
+    const res = await axiosClient().post("/posts", { value });
+    if (res.status !== 200 || !res.data) {
+      return { status: false };
+    }
+    return { status: true, data: res.data };
+  } catch (error) {
+    console.log(error);
+    return { status: false };
+  }
+}

--- a/front/worker/index.js
+++ b/front/worker/index.js
@@ -1,0 +1,1 @@
+self.__WB_DISABLE_DEV_LOGS=true

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -7,7 +7,7 @@
   resolved "https://registry.yarnpkg.com/@alloc/quick-lru/-/quick-lru-5.2.0.tgz#7bf68b20c0a350f936915fcae06f58e32007ce30"
   integrity sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==
 
-"@babel/runtime@^7.23.2":
+"@babel/runtime@^7.20.13", "@babel/runtime@^7.23.2":
   version "7.24.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.7.tgz#f4f0d5530e8dbdf59b3451b9b3e594b6ba082e12"
   integrity sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==
@@ -45,6 +45,42 @@
   version "8.57.0"
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.0.tgz#a5417ae8427873f1dd08b70b3574b453e67b5f7f"
   integrity sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==
+
+"@floating-ui/core@^1.0.0":
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.6.2.tgz#d37f3e0ac1f1c756c7de45db13303a266226851a"
+  integrity sha512-+2XpQV9LLZeanU4ZevzRnGFg2neDeKHgFLjP6YLW+tly0IvrhqT4u8enLGjLH3qeh85g19xY5rsAusfwTdn5lg==
+  dependencies:
+    "@floating-ui/utils" "^0.2.0"
+
+"@floating-ui/dom@^1.0.0":
+  version "1.6.5"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.6.5.tgz#323f065c003f1d3ecf0ff16d2c2c4d38979f4cb9"
+  integrity sha512-Nsdud2X65Dz+1RHjAIP0t8z5e2ff/IRbei6BqFrl1urT8sDVzM1HMQ+R0XcU5ceRfyO3I6ayeqIfh+6Wb8LGTw==
+  dependencies:
+    "@floating-ui/core" "^1.0.0"
+    "@floating-ui/utils" "^0.2.0"
+
+"@floating-ui/react-dom@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.1.0.tgz#4f0e5e9920137874b2405f7d6c862873baf4beff"
+  integrity sha512-lNzj5EQmEKn5FFKc04+zasr09h/uX8RtJRNj5gUXsSQIXHVWTVh+hVAg1vOMCexkX8EgvemMvIFpQfkosnVNyA==
+  dependencies:
+    "@floating-ui/dom" "^1.0.0"
+
+"@floating-ui/react@^0.26.9":
+  version "0.26.16"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react/-/react-0.26.16.tgz#3415a087f452165161c2d313d1d57e8142894679"
+  integrity sha512-HEf43zxZNAI/E781QIVpYSF3K2VH4TTYZpqecjdsFkjsaU1EbaWcM++kw0HXFffj7gDUcBFevX8s0rQGQpxkow==
+  dependencies:
+    "@floating-ui/react-dom" "^2.1.0"
+    "@floating-ui/utils" "^0.2.0"
+    tabbable "^6.0.0"
+
+"@floating-ui/utils@^0.2.0":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.2.tgz#d8bae93ac8b815b2bd7a98078cf91e2724ef11e5"
+  integrity sha512-J4yDIIthosAsRZ5CPYP/jQvUAQtlZTTD/4suA08/FEnlxqW3sKS9iAhgsa9VYLZ6vDHn/ixJgIqRQPotoBjxIw==
 
 "@humanwhocodes/config-array@^0.11.14":
   version "0.11.14"
@@ -108,6 +144,31 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
+
+"@mantine/core@^7.10.1":
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@mantine/core/-/core-7.10.1.tgz#c90a2aed1e47ece38f745db11c1cff56fd5719b9"
+  integrity sha512-l9ypojKN3PjwO1CSLIsqxi7mA25+7w+xc71Q+JuCCREI0tuGwkZsKbIOpuTATIJOjPh8ycLiW7QxX1LYsRTq6w==
+  dependencies:
+    "@floating-ui/react" "^0.26.9"
+    clsx "^2.1.1"
+    react-number-format "^5.3.1"
+    react-remove-scroll "^2.5.7"
+    react-textarea-autosize "8.5.3"
+    type-fest "^4.12.0"
+
+"@mantine/form@^7.10.1":
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@mantine/form/-/form-7.10.1.tgz#86b867454b7490f4ca58c924d85d4170520cec4d"
+  integrity sha512-mZwzg4GEWKEDKEIZu9FmSpGFzYYhFD2YArVOXUM0MMciUqX7yxSCon1PaPJxrV8ldc6FE+JLVI2+G2KVxJ3ZXA==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    klona "^2.0.6"
+
+"@mantine/hooks@^7.10.1":
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@mantine/hooks/-/hooks-7.10.1.tgz#68d12570f0dad127555904973ec78ae40065ae31"
+  integrity sha512-0EH9WBWUdtQLGU3Ak+csQ77EtUxI6pPNfwZdRJQWcaA3f8SFOLo9h9CGxiikFExerhvuCeUlaTf3s+TB9Op/rw==
 
 "@next/env@14.2.3":
   version "14.2.3"
@@ -716,6 +777,11 @@ client-only@0.0.1, client-only@^0.0.1:
   resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
   integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
 
+clsx@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
+  integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
+
 color-convert@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
@@ -852,6 +918,11 @@ dequal@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
   integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+
+detect-node-es@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node-es/-/detect-node-es-1.1.0.tgz#163acdf643330caa0b4cd7c21e7ee7755d6fa493"
+  integrity sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==
 
 didyoumean@^1.2.2:
   version "1.2.2"
@@ -1417,6 +1488,11 @@ get-intrinsic@^1.1.3, get-intrinsic@^1.2.1, get-intrinsic@^1.2.3, get-intrinsic@
     has-symbols "^1.0.3"
     hasown "^2.0.0"
 
+get-nonce@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-nonce/-/get-nonce-1.0.1.tgz#fdf3f0278073820d2ce9426c18f07481b1e0cdf3"
+  integrity sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==
+
 get-stream@^8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-8.0.1.tgz#def9dfd71742cd7754a7761ed43749a27d02eca2"
@@ -1625,6 +1701,13 @@ internal-slot@^1.0.7:
     es-errors "^1.3.0"
     hasown "^2.0.0"
     side-channel "^1.0.4"
+
+invariant@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
+  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
+  dependencies:
+    loose-envify "^1.0.0"
 
 is-array-buffer@^3.0.4:
   version "3.0.4"
@@ -1925,6 +2008,11 @@ keyv@^4.5.3:
   dependencies:
     json-buffer "3.0.1"
 
+klona@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.6.tgz#85bffbf819c03b2f53270412420a4555ef882e22"
+  integrity sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==
+
 language-subtag-registry@^0.3.20:
   version "0.3.23"
   resolved "https://registry.yarnpkg.com/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz#23529e04d9e3b74679d70142df3fd2eb6ec572e7"
@@ -2011,7 +2099,7 @@ log-update@^6.0.0:
     strip-ansi "^7.1.0"
     wrap-ansi "^9.0.0"
 
-loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -2433,7 +2521,7 @@ prettier@^3.3.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.1.tgz#e68935518dd90bb7ec4821ba970e68f8de16e1ac"
   integrity sha512-7CAwy5dRsxs8PHXT3twixW9/OEll8MLE0VRPCJyl7CkS6VHGPSlsVaWTiASPTyGyYRyApxlaWTzwUxVNrhcwDg==
 
-prop-types@^15.8.1:
+prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -2469,6 +2557,50 @@ react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-number-format@^5.3.1:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/react-number-format/-/react-number-format-5.4.0.tgz#8c1e97add1970d1a2f372ca286bcdaa49632ba5c"
+  integrity sha512-NWdICrqLhI7rAS8yUeLVd6Wr4cN7UjJ9IBTS0f/a9i7UB4x4Ti70kGnksBtZ7o4Z7YRbvCMMR/jQmkoOBa/4fg==
+  dependencies:
+    prop-types "^15.7.2"
+
+react-remove-scroll-bar@^2.3.6:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.6.tgz#3e585e9d163be84a010180b18721e851ac81a29c"
+  integrity sha512-DtSYaao4mBmX+HDo5YWYdBWQwYIQQshUV/dVxFxK+KM26Wjwp1gZ6rv6OC3oujI6Bfu6Xyg3TwK533AQutsn/g==
+  dependencies:
+    react-style-singleton "^2.2.1"
+    tslib "^2.0.0"
+
+react-remove-scroll@^2.5.7:
+  version "2.5.10"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.5.10.tgz#5fae456a23962af6d3c38ca1978bcfe0806c4061"
+  integrity sha512-m3zvBRANPBw3qxVVjEIPEQinkcwlFZ4qyomuWVpNJdv4c6MvHfXV0C3L9Jx5rr3HeBHKNRX+1jreB5QloDIJjA==
+  dependencies:
+    react-remove-scroll-bar "^2.3.6"
+    react-style-singleton "^2.2.1"
+    tslib "^2.1.0"
+    use-callback-ref "^1.3.0"
+    use-sidecar "^1.1.2"
+
+react-style-singleton@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-style-singleton/-/react-style-singleton-2.2.1.tgz#f99e420492b2d8f34d38308ff660b60d0b1205b4"
+  integrity sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==
+  dependencies:
+    get-nonce "^1.0.0"
+    invariant "^2.2.4"
+    tslib "^2.0.0"
+
+react-textarea-autosize@8.5.3:
+  version "8.5.3"
+  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-8.5.3.tgz#d1e9fe760178413891484847d3378706052dd409"
+  integrity sha512-XT1024o2pqCuZSuBt9FwHlaDeNtVrtCXu0Rnz88t1jUGheCLa3PhjE1GH8Ctm2axEtvdCl5SUHYschyQ0L5QHQ==
+  dependencies:
+    "@babel/runtime" "^7.20.13"
+    use-composed-ref "^1.3.0"
+    use-latest "^1.2.1"
 
 react@^18:
   version "18.3.1"
@@ -2855,6 +2987,11 @@ swr@^2.2.5:
     client-only "^0.0.1"
     use-sync-external-store "^1.2.0"
 
+tabbable@^6.0.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.2.0.tgz#732fb62bc0175cfcec257330be187dcfba1f3b97"
+  integrity sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==
+
 tailwindcss@^3.4.1:
   version "3.4.4"
   resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.4.4.tgz#351d932273e6abfa75ce7d226b5bf3a6cb257c05"
@@ -2934,7 +3071,7 @@ tsconfig-paths@^3.15.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^2.4.0:
+tslib@^2.0.0, tslib@^2.1.0, tslib@^2.4.0:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.3.tgz#0438f810ad7a9edcde7a241c3d80db693c8cbfe0"
   integrity sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==
@@ -2950,6 +3087,11 @@ type-fest@^0.20.2:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+
+type-fest@^4.12.0:
+  version "4.20.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.20.0.tgz#019becf5a97cd58eee93f592f0961859a74482a7"
+  integrity sha512-MBh+PHUHHisjXf4tlx0CFWoMdjx8zCMLJHOjnV1prABYZFHqtFOyauCIK2/7w4oIfwkF8iNhLtnJEfVY2vn3iw==
 
 typed-array-buffer@^1.0.2:
   version "1.0.2"
@@ -3021,6 +3163,38 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+use-callback-ref@^1.3.0:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.3.2.tgz#6134c7f6ff76e2be0b56c809b17a650c942b1693"
+  integrity sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==
+  dependencies:
+    tslib "^2.0.0"
+
+use-composed-ref@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/use-composed-ref/-/use-composed-ref-1.3.0.tgz#3d8104db34b7b264030a9d916c5e94fbe280dbda"
+  integrity sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==
+
+use-isomorphic-layout-effect@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz#497cefb13d863d687b08477d9e5a164ad8c1a6fb"
+  integrity sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==
+
+use-latest@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/use-latest/-/use-latest-1.2.1.tgz#d13dfb4b08c28e3e33991546a2cee53e14038cf2"
+  integrity sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==
+  dependencies:
+    use-isomorphic-layout-effect "^1.1.1"
+
+use-sidecar@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.1.2.tgz#2f43126ba2d7d7e117aa5855e5d8f0276dfe73c2"
+  integrity sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==
+  dependencies:
+    detect-node-es "^1.1.0"
+    tslib "^2.0.0"
 
 use-sync-external-store@^1.2.0:
   version "1.2.2"


### PR DESCRIPTION
## 概要
投稿画面および投稿の演出を行いました。

## 紐づく issue
close #9

## チェック項目
- [x] 本文を書けること
- [x] 本文の入力文字数が表示されていること
- [x] 名前の記入欄があること
- [x] 名前の入力文字数が表示されていること
- [x] ジャンルの記入欄があること（オートコンプリート）
- [x] タグの記入欄があること（オートコンプリート）
- [x] 投函ボタンがあること
- [ ] 投函に成功したらトーストを表示して詳細ページへ飛べるようにしてあること（実装の順番的に遷移はまだで良い）
   ⇨ 演出を入れています。
- [ ] 投函に失敗したらモーダルで失敗理由が表示されること
   ⇨ 演出を入れたので失敗時の演出を考え中です
- [x] そもそも本文がなければ投函できないこと
- [x] 本文や名前が文字数オーバーしていたら投函できないこと
- [x] 本文や名前が文字数オーバーしていたら投函ボタンの近くに「文字数オーバーしています」と表示されること

### 未実装の項目
投稿失敗時の表示は未実装です

## 挙動
投稿画面
| PC | SP |
| --- | --- |
| <img src="https://i.gyazo.com/9dc3b76406706b497621f4b493aae024.png" width="500px" /> | <img src="https://i.gyazo.com/3a27ff7c0e73db2b55e12a020eece35d.png" width="200px" /> |

投稿演出
| PC | SP |
| --- | --- |
| <img src="https://i.gyazo.com/c3f1591a032ab1801c6b1ff66c8dee23.gif" width="500px" /> | <img src="https://i.gyazo.com/7460ded9c6cf4430a1429a785aac5832.gif" width="200px" /> |

## 補足
オートコンプリートとしてMantineを導入しました。
選定基準は下記のとおりです。
- ドキュメントが読みやすい
- クセがなくCSSのカスタマイズがしやすい
- オートコンプリートがある
- タグ入力ができる
- フォームバリデーションが使いやすい

shadocn/uiも考えたのですが、学習コストがやや高かったためやめました。

## 参考
ジャンルやタグの見出しデザイン
[マスキングテープ風デザインCSS　ガーリーデザインのサイトやブログに](https://blog.minimal-green.com/entry/2017/01/14/211630)
