### PR TITLE
【feature】投稿一覧の画面作成 close #12

### DIFF
--- a/front/src/app/globals.css
+++ b/front/src/app/globals.css
@@ -226,6 +226,7 @@ body {
   align-items: center;
   position: relative;
   width: 100%;
+  height: 320px;
   perspective: 1000px; /* 3Dの深さを設定 */
 }
 

--- a/front/src/app/globals.css
+++ b/front/src/app/globals.css
@@ -6,22 +6,10 @@
 /* ================================== */
 /*            GoogleFonts             */
 /* ================================== */
-.lxgw-wenkai-tc-light {
-  font-family: "LXGW WenKai TC", cursive;
-  font-weight: 300;
-  font-style: normal;
-}
-
-.lxgw-wenkai-tc-regular {
-  font-family: "LXGW WenKai TC", cursive;
+body {
+  font-family: "Klee One", "LXGW WenKai TC", "Times New Roman", "YuMincho", "Hiragino Mincho ProN",
+    "Yu Mincho", "MS PMincho", serif;
   font-weight: 400;
-  font-style: normal;
-}
-
-.lxgw-wenkai-tc-bold {
-  font-family: "LXGW WenKai TC", cursive;
-  font-weight: 700;
-  font-style: normal;
 }
 
 /* ================================== */
@@ -195,7 +183,8 @@
 /* ================================== */
 /*                 UI                 */
 /* ================================== */
-.stripe-pattern {
+.stripe-pattern-sky,
+.mantine-Modal-header {
   position: relative;
   background: repeating-linear-gradient(
     -45deg,
@@ -206,6 +195,163 @@
   );
   border-left: 2px dotted rgba(0, 0, 0, 0.1);
   border-right: 2px dotted rgba(0, 0, 0, 0.1);
-  box-shadow: 0 0 5px rgba(0, 0, 0, 0.2);
   transform: translateX(-4px) translateY(3px) rotateZ(-5deg);
+}
+
+.stripe-pattern-orange {
+  position: relative;
+  background: repeating-linear-gradient(
+    -45deg,
+    rgba(255, 238, 142, 0.514),
+    rgba(255, 238, 142, 0.514) 10px,
+    #fff 0,
+    #fff 20px
+  );
+  border-left: 2px dotted rgba(0, 0, 0, 0.1);
+  border-right: 2px dotted rgba(0, 0, 0, 0.1);
+  transform: translateX(-4px) translateY(3px) rotateZ(-5deg);
+}
+
+.mantine-Modal-content {
+  border-radius: 0%;
+}
+
+/* ================================== */
+/*                手紙                */
+/* ================================== */
+
+.envelope-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  width: 100%;
+  perspective: 1000px; /* 3Dの深さを設定 */
+}
+
+.envelope {
+  width: 0;
+  height: 0;
+  z-index: 0;
+  border-style: solid;
+  border-width: 0 150px 100px 150px;
+  border-color: transparent transparent #e2e2e2 transparent;
+  box-shadow:
+    0 100px 0 0 #e2e2e2,
+    0 150px 90px 0 rgba(0, 0, 0, 0.2);
+  transform-origin: center;
+  transition: transform 0.5s ease-in-out;
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+.envelope1 {
+  z-index: 5;
+  transform: rotateX(20deg) rotateY(20deg) rotateZ(-10deg);
+}
+.envelope2 {
+  z-index: 4;
+  transform: rotateX(15deg) rotateY(15deg) rotateZ(-8deg);
+}
+.envelope3 {
+  z-index: 3;
+  transform: rotateX(10deg) rotateY(10deg) rotateZ(-6deg);
+}
+.envelope4 {
+  z-index: 2;
+  transform: rotateX(5deg) rotateY(5deg) rotateZ(-4deg);
+}
+.envelope5 {
+  z-index: 1;
+  transform: rotateX(2deg) rotateY(2deg) rotateZ(-2deg);
+}
+
+.envelope:after,
+.envelope:before {
+  content: "";
+  display: block;
+  position: absolute;
+  top: 100px;
+  border-style: solid;
+}
+
+.envelope:after {
+  width: 0;
+  height: 0;
+  left: 0;
+  border-width: 100px 150px 100px 0;
+  border-color: transparent #f1f1f1 transparent transparent;
+}
+
+.envelope:before {
+  width: 210px;
+  height: 180px;
+  left: -150px;
+  border-width: 200px 0 0 300px;
+  border-color: transparent transparent transparent #f1f1f1;
+}
+
+.envelope-container:hover .envelope1 {
+  transform: rotateX(0deg) rotateY(0deg) rotateZ(0deg);
+}
+
+.envelope-container:hover .envelope2 {
+  transform: rotateX(-15deg) rotateY(-15deg) rotateZ(8deg);
+}
+
+.envelope-container:hover .envelope3 {
+  transform: rotateX(-10deg) rotateY(-10deg) rotateZ(6deg);
+}
+
+.envelope-container:hover .envelope4 {
+  transform: rotateX(-5deg) rotateY(-5deg) rotateZ(4deg);
+}
+
+.envelope-container:hover .envelope5 {
+  transform: rotateX(-2deg) rotateY(-2deg) rotateZ(2deg);
+}
+
+.card {
+  width: 260px;
+  height: 220px;
+  top: 70px;
+  left: -130px;
+  z-index: -1;
+  background-color: #ffffff;
+  border-radius: 5px;
+  transition: transform 0.5s ease-in-out;
+  text-align: center;
+  letter-spacing: 0.06em;
+  padding-top: 130px;
+  color: #383838;
+}
+
+.envelope-container:hover .envelope1 .card {
+  transform: translateY(-100px);
+}
+
+.card p {
+  width: 150px;
+  margin: 0 auto;
+}
+
+.postmark {
+  position: relative;
+  margin: 0;
+  padding: 10px;
+  width: 50px;
+  height: 50px;
+  border: 5px double #430;
+  -webkit-border-radius: 50%;
+  -moz-border-radius: 50%;
+  border-radius: 50%;
+  color: #430;
+  text-align: center;
+  font-size: 20px;
+  line-height: 20px;
+  -webkit-transform: rotate(16deg);
+  -ms-transform: rotate(16deg);
+  transform: rotate(16deg);
+  white-space: nowrap;
 }

--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -19,8 +19,14 @@ export default function RootLayout({
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" />
+        {/* 句読点だけKlee One */}
         <link
-          href="https://fonts.googleapis.com/css2?family=LXGW+WenKai+TC:wght@300;400;700&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Klee+One&text=、。&display=swap"
+          rel="stylesheet"
+        />
+        {/* 基本の文字はLXGW WenKai TC */}
+        <link
+          href="https://fonts.googleapis.com/css2?family=LXGW+WenKai+TC&display=swap"
           rel="stylesheet"
         />
       </head>

--- a/front/src/app/posts/page.tsx
+++ b/front/src/app/posts/page.tsx
@@ -1,9 +1,96 @@
+"use client";
+
+import { Modal } from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
+import Link from "next/link";
+
 export default function Posts() {
+  const [opened, { open, close }] = useDisclosure(false);
+
   return (
-    <article>
-      <section>
-        <h1>投稿一覧</h1>
-      </section>
-    </article>
+    <>
+      <article className="container m-auto">
+        <h1 className="text-center text-xl">みんなの手紙</h1>
+        <div className="my-12 grid grid-cols-1 gap-72 sm:grid-cols-2 md:grid-cols-3 md:gap-x-0 lg:grid-cols-3">
+          {/* ここから手紙 */}
+          <section className="envelope-container group">
+            <div className="envelope envelope1 relative">
+              <div className="card absolute overflow-hidden">
+                <div className="absolute top-0 z-20 whitespace-pre-wrap p-4 text-sm">
+                  ダミーテキストダミーテキストダミーテキストダミーテキストダミーテキスト
+                </div>
+              </div>
+              <div className="absolute -left-[140px] top-[230px] z-10 flex w-[280px] flex-col items-start justify-center gap-3 text-sm">
+                <button
+                  type="button"
+                  className="stripe-pattern-sky px-2 text-slate-700"
+                  onClick={open}
+                >
+                  どんな手紙？
+                </button>
+                <Link href="" className="stripe-pattern-orange px-2 text-slate-700">
+                  手紙を読む
+                </Link>
+              </div>
+              <div className="absolute -right-[120px] top-[200px] z-10 flex flex-col items-start justify-center gap-3 text-sm">
+                <div className="postmark">
+                  1<span className="text-sm">通</span>
+                </div>
+              </div>
+              <div className="absolute -right-[140px] top-[275px] z-10 flex w-[180px] flex-col items-start justify-center gap-3 text-end text-sm">
+                <p className="w-full">ダミーユーザー より</p>
+              </div>
+            </div>
+            <div className="envelope envelope2 relative">
+              <div className="card absolute"></div>
+            </div>
+            <div className="envelope envelope3 relative">
+              <div className="card absolute"></div>
+            </div>
+            <div className="envelope envelope4 relative">
+              <div className="card absolute"></div>
+            </div>
+            <div className="envelope envelope5 relative">
+              <div className="card absolute"></div>
+            </div>
+          </section>
+          {/* ここまで手紙 */}
+        </div>
+      </article>
+      <Modal opened={opened} onClose={close} title="どんな手紙？">
+        <div className="relative mt-8 bg-white px-2">
+          <h3>
+            <span className="border-b border-sky-600 px-2">ジャンル</span>
+          </h3>
+          <ul className="border-b border-dashed border-sky-300 pb-2">
+            <li>ダミーテキスト</li>
+            <li>ダミーテキスト</li>
+            <li>ダミーテキスト</li>
+            <li>ダミーテキスト</li>
+            <li>ダミーテキスト</li>
+          </ul>
+          <h3 className="pt-2">
+            <span className="border-b border-sky-600 px-2">タグ</span>
+          </h3>
+          <ul>
+            <li>ダミーテキスト</li>
+            <li>ダミーテキスト</li>
+            <li>ダミーテキスト</li>
+            <li>あいうえお</li>
+            <li>ダミーテキスト</li>
+          </ul>
+          <div className="absolute bottom-8 right-0 opacity-50">
+            <div className="postmark">
+              1<span className="text-sm">通</span>
+            </div>
+          </div>
+          <div className="text-end">
+            <Link href="" className="stripe-pattern-orange px-2 text-slate-700">
+              手紙を読む
+            </Link>
+          </div>
+        </div>
+      </Modal>
+    </>
   );
 }

--- a/front/src/app/posts/page.tsx
+++ b/front/src/app/posts/page.tsx
@@ -9,9 +9,9 @@ export default function Posts() {
 
   return (
     <>
-      <article className="container m-auto">
+      <article className="container relative m-auto">
         <h1 className="text-center text-xl">みんなの手紙</h1>
-        <div className="my-12 grid grid-cols-1 gap-72 sm:grid-cols-2 md:grid-cols-3 md:gap-x-0 lg:grid-cols-3">
+        <div className="my-12 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3">
           {/* ここから手紙 */}
           <section className="envelope-container group">
             <div className="envelope envelope1 relative">
@@ -55,6 +55,334 @@ export default function Posts() {
             </div>
           </section>
           {/* ここまで手紙 */}
+          <section className="envelope-container group">
+            <div className="envelope envelope1 relative">
+              <div className="card absolute overflow-hidden">
+                <div className="absolute top-0 z-20 whitespace-pre-wrap p-4 text-sm">
+                  ダミーテキストダミーテキストダミーテキストダミーテキストダミーテキスト
+                </div>
+              </div>
+              <div className="absolute -left-[140px] top-[230px] z-10 flex w-[280px] flex-col items-start justify-center gap-3 text-sm">
+                <button
+                  type="button"
+                  className="stripe-pattern-sky px-2 text-slate-700"
+                  onClick={open}
+                >
+                  どんな手紙？
+                </button>
+                <Link href="" className="stripe-pattern-orange px-2 text-slate-700">
+                  手紙を読む
+                </Link>
+              </div>
+              <div className="absolute -right-[120px] top-[200px] z-10 flex flex-col items-start justify-center gap-3 text-sm">
+                <div className="postmark">
+                  1<span className="text-sm">通</span>
+                </div>
+              </div>
+              <div className="absolute -right-[140px] top-[275px] z-10 flex w-[180px] flex-col items-start justify-center gap-3 text-end text-sm">
+                <p className="w-full">ダミーユーザー より</p>
+              </div>
+            </div>
+            <div className="envelope envelope2 relative">
+              <div className="card absolute"></div>
+            </div>
+            <div className="envelope envelope3 relative">
+              <div className="card absolute"></div>
+            </div>
+            <div className="envelope envelope4 relative">
+              <div className="card absolute"></div>
+            </div>
+            <div className="envelope envelope5 relative">
+              <div className="card absolute"></div>
+            </div>
+          </section>
+          <section className="envelope-container group">
+            <div className="envelope envelope1 relative">
+              <div className="card absolute overflow-hidden">
+                <div className="absolute top-0 z-20 whitespace-pre-wrap p-4 text-sm">
+                  ダミーテキストダミーテキストダミーテキストダミーテキストダミーテキスト
+                </div>
+              </div>
+              <div className="absolute -left-[140px] top-[230px] z-10 flex w-[280px] flex-col items-start justify-center gap-3 text-sm">
+                <button
+                  type="button"
+                  className="stripe-pattern-sky px-2 text-slate-700"
+                  onClick={open}
+                >
+                  どんな手紙？
+                </button>
+                <Link href="" className="stripe-pattern-orange px-2 text-slate-700">
+                  手紙を読む
+                </Link>
+              </div>
+              <div className="absolute -right-[120px] top-[200px] z-10 flex flex-col items-start justify-center gap-3 text-sm">
+                <div className="postmark">
+                  1<span className="text-sm">通</span>
+                </div>
+              </div>
+              <div className="absolute -right-[140px] top-[275px] z-10 flex w-[180px] flex-col items-start justify-center gap-3 text-end text-sm">
+                <p className="w-full">ダミーユーザー より</p>
+              </div>
+            </div>
+            <div className="envelope envelope2 relative">
+              <div className="card absolute"></div>
+            </div>
+            <div className="envelope envelope3 relative">
+              <div className="card absolute"></div>
+            </div>
+            <div className="envelope envelope4 relative">
+              <div className="card absolute"></div>
+            </div>
+            <div className="envelope envelope5 relative">
+              <div className="card absolute"></div>
+            </div>
+          </section>
+          <section className="envelope-container group">
+            <div className="envelope envelope1 relative">
+              <div className="card absolute overflow-hidden">
+                <div className="absolute top-0 z-20 whitespace-pre-wrap p-4 text-sm">
+                  ダミーテキストダミーテキストダミーテキストダミーテキストダミーテキスト
+                </div>
+              </div>
+              <div className="absolute -left-[140px] top-[230px] z-10 flex w-[280px] flex-col items-start justify-center gap-3 text-sm">
+                <button
+                  type="button"
+                  className="stripe-pattern-sky px-2 text-slate-700"
+                  onClick={open}
+                >
+                  どんな手紙？
+                </button>
+                <Link href="" className="stripe-pattern-orange px-2 text-slate-700">
+                  手紙を読む
+                </Link>
+              </div>
+              <div className="absolute -right-[120px] top-[200px] z-10 flex flex-col items-start justify-center gap-3 text-sm">
+                <div className="postmark">
+                  1<span className="text-sm">通</span>
+                </div>
+              </div>
+              <div className="absolute -right-[140px] top-[275px] z-10 flex w-[180px] flex-col items-start justify-center gap-3 text-end text-sm">
+                <p className="w-full">ダミーユーザー より</p>
+              </div>
+            </div>
+            <div className="envelope envelope2 relative">
+              <div className="card absolute"></div>
+            </div>
+            <div className="envelope envelope3 relative">
+              <div className="card absolute"></div>
+            </div>
+            <div className="envelope envelope4 relative">
+              <div className="card absolute"></div>
+            </div>
+            <div className="envelope envelope5 relative">
+              <div className="card absolute"></div>
+            </div>
+          </section>
+          <section className="envelope-container group">
+            <div className="envelope envelope1 relative">
+              <div className="card absolute overflow-hidden">
+                <div className="absolute top-0 z-20 whitespace-pre-wrap p-4 text-sm">
+                  ダミーテキストダミーテキストダミーテキストダミーテキストダミーテキスト
+                </div>
+              </div>
+              <div className="absolute -left-[140px] top-[230px] z-10 flex w-[280px] flex-col items-start justify-center gap-3 text-sm">
+                <button
+                  type="button"
+                  className="stripe-pattern-sky px-2 text-slate-700"
+                  onClick={open}
+                >
+                  どんな手紙？
+                </button>
+                <Link href="" className="stripe-pattern-orange px-2 text-slate-700">
+                  手紙を読む
+                </Link>
+              </div>
+              <div className="absolute -right-[120px] top-[200px] z-10 flex flex-col items-start justify-center gap-3 text-sm">
+                <div className="postmark">
+                  1<span className="text-sm">通</span>
+                </div>
+              </div>
+              <div className="absolute -right-[140px] top-[275px] z-10 flex w-[180px] flex-col items-start justify-center gap-3 text-end text-sm">
+                <p className="w-full">ダミーユーザー より</p>
+              </div>
+            </div>
+            <div className="envelope envelope2 relative">
+              <div className="card absolute"></div>
+            </div>
+            <div className="envelope envelope3 relative">
+              <div className="card absolute"></div>
+            </div>
+            <div className="envelope envelope4 relative">
+              <div className="card absolute"></div>
+            </div>
+            <div className="envelope envelope5 relative">
+              <div className="card absolute"></div>
+            </div>
+          </section>
+          <section className="envelope-container group">
+            <div className="envelope envelope1 relative">
+              <div className="card absolute overflow-hidden">
+                <div className="absolute top-0 z-20 whitespace-pre-wrap p-4 text-sm">
+                  ダミーテキストダミーテキストダミーテキストダミーテキストダミーテキスト
+                </div>
+              </div>
+              <div className="absolute -left-[140px] top-[230px] z-10 flex w-[280px] flex-col items-start justify-center gap-3 text-sm">
+                <button
+                  type="button"
+                  className="stripe-pattern-sky px-2 text-slate-700"
+                  onClick={open}
+                >
+                  どんな手紙？
+                </button>
+                <Link href="" className="stripe-pattern-orange px-2 text-slate-700">
+                  手紙を読む
+                </Link>
+              </div>
+              <div className="absolute -right-[120px] top-[200px] z-10 flex flex-col items-start justify-center gap-3 text-sm">
+                <div className="postmark">
+                  1<span className="text-sm">通</span>
+                </div>
+              </div>
+              <div className="absolute -right-[140px] top-[275px] z-10 flex w-[180px] flex-col items-start justify-center gap-3 text-end text-sm">
+                <p className="w-full">ダミーユーザー より</p>
+              </div>
+            </div>
+            <div className="envelope envelope2 relative">
+              <div className="card absolute"></div>
+            </div>
+            <div className="envelope envelope3 relative">
+              <div className="card absolute"></div>
+            </div>
+            <div className="envelope envelope4 relative">
+              <div className="card absolute"></div>
+            </div>
+            <div className="envelope envelope5 relative">
+              <div className="card absolute"></div>
+            </div>
+          </section>
+          <section className="envelope-container group">
+            <div className="envelope envelope1 relative">
+              <div className="card absolute overflow-hidden">
+                <div className="absolute top-0 z-20 whitespace-pre-wrap p-4 text-sm">
+                  ダミーテキストダミーテキストダミーテキストダミーテキストダミーテキスト
+                </div>
+              </div>
+              <div className="absolute -left-[140px] top-[230px] z-10 flex w-[280px] flex-col items-start justify-center gap-3 text-sm">
+                <button
+                  type="button"
+                  className="stripe-pattern-sky px-2 text-slate-700"
+                  onClick={open}
+                >
+                  どんな手紙？
+                </button>
+                <Link href="" className="stripe-pattern-orange px-2 text-slate-700">
+                  手紙を読む
+                </Link>
+              </div>
+              <div className="absolute -right-[120px] top-[200px] z-10 flex flex-col items-start justify-center gap-3 text-sm">
+                <div className="postmark">
+                  1<span className="text-sm">通</span>
+                </div>
+              </div>
+              <div className="absolute -right-[140px] top-[275px] z-10 flex w-[180px] flex-col items-start justify-center gap-3 text-end text-sm">
+                <p className="w-full">ダミーユーザー より</p>
+              </div>
+            </div>
+            <div className="envelope envelope2 relative">
+              <div className="card absolute"></div>
+            </div>
+            <div className="envelope envelope3 relative">
+              <div className="card absolute"></div>
+            </div>
+            <div className="envelope envelope4 relative">
+              <div className="card absolute"></div>
+            </div>
+            <div className="envelope envelope5 relative">
+              <div className="card absolute"></div>
+            </div>
+          </section>
+          <section className="envelope-container group">
+            <div className="envelope envelope1 relative">
+              <div className="card absolute overflow-hidden">
+                <div className="absolute top-0 z-20 whitespace-pre-wrap p-4 text-sm">
+                  ダミーテキストダミーテキストダミーテキストダミーテキストダミーテキスト
+                </div>
+              </div>
+              <div className="absolute -left-[140px] top-[230px] z-10 flex w-[280px] flex-col items-start justify-center gap-3 text-sm">
+                <button
+                  type="button"
+                  className="stripe-pattern-sky px-2 text-slate-700"
+                  onClick={open}
+                >
+                  どんな手紙？
+                </button>
+                <Link href="" className="stripe-pattern-orange px-2 text-slate-700">
+                  手紙を読む
+                </Link>
+              </div>
+              <div className="absolute -right-[120px] top-[200px] z-10 flex flex-col items-start justify-center gap-3 text-sm">
+                <div className="postmark">
+                  1<span className="text-sm">通</span>
+                </div>
+              </div>
+              <div className="absolute -right-[140px] top-[275px] z-10 flex w-[180px] flex-col items-start justify-center gap-3 text-end text-sm">
+                <p className="w-full">ダミーユーザー より</p>
+              </div>
+            </div>
+            <div className="envelope envelope2 relative">
+              <div className="card absolute"></div>
+            </div>
+            <div className="envelope envelope3 relative">
+              <div className="card absolute"></div>
+            </div>
+            <div className="envelope envelope4 relative">
+              <div className="card absolute"></div>
+            </div>
+            <div className="envelope envelope5 relative">
+              <div className="card absolute"></div>
+            </div>
+          </section>
+          <section className="envelope-container group">
+            <div className="envelope envelope1 relative">
+              <div className="card absolute overflow-hidden">
+                <div className="absolute top-0 z-20 whitespace-pre-wrap p-4 text-sm">
+                  ダミーテキストダミーテキストダミーテキストダミーテキストダミーテキスト
+                </div>
+              </div>
+              <div className="absolute -left-[140px] top-[230px] z-10 flex w-[280px] flex-col items-start justify-center gap-3 text-sm">
+                <button
+                  type="button"
+                  className="stripe-pattern-sky px-2 text-slate-700"
+                  onClick={open}
+                >
+                  どんな手紙？
+                </button>
+                <Link href="" className="stripe-pattern-orange px-2 text-slate-700">
+                  手紙を読む
+                </Link>
+              </div>
+              <div className="absolute -right-[120px] top-[200px] z-10 flex flex-col items-start justify-center gap-3 text-sm">
+                <div className="postmark">
+                  1<span className="text-sm">通</span>
+                </div>
+              </div>
+              <div className="absolute -right-[140px] top-[275px] z-10 flex w-[180px] flex-col items-start justify-center gap-3 text-end text-sm">
+                <p className="w-full">ダミーユーザー より</p>
+              </div>
+            </div>
+            <div className="envelope envelope2 relative">
+              <div className="card absolute"></div>
+            </div>
+            <div className="envelope envelope3 relative">
+              <div className="card absolute"></div>
+            </div>
+            <div className="envelope envelope4 relative">
+              <div className="card absolute"></div>
+            </div>
+            <div className="envelope envelope5 relative">
+              <div className="card absolute"></div>
+            </div>
+          </section>
         </div>
       </article>
       <Modal opened={opened} onClose={close} title="どんな手紙？">

--- a/front/src/components/forms/tagsInput/index.tsx
+++ b/front/src/components/forms/tagsInput/index.tsx
@@ -13,7 +13,7 @@ export default function TagsInput({
 }) {
   return (
     <>
-      <Mantine.InputLabel className="stripe-pattern px-2">{label}</Mantine.InputLabel>
+      <Mantine.InputLabel className="stripe-pattern-sky px-2">{label}</Mantine.InputLabel>
       <Mantine.TagsInput
         name="genres"
         placeholder={placeholder}

--- a/front/src/components/layouts/headers/index.tsx
+++ b/front/src/components/layouts/headers/index.tsx
@@ -38,13 +38,13 @@ export default function Headers() {
   return (
     <>
       <div className="relative w-full">
-        <h1 className="border-b border-dashed border-sky-300 bg-white py-2 text-center text-2xl md:py-6">
+        <h1 className="z-30 border-b border-dashed border-sky-300 bg-white py-2 text-center text-2xl md:py-6">
           <Link href={Routes.home}>言の葉つづり</Link>
         </h1>
         <Motion.motion.nav
           id="menu"
           animate={isOpen ? "open" : "closed"}
-          className={isOpen ? "absolute left-0 top-0 z-50 w-full bg-black bg-opacity-40" : ""}
+          className={`z-50 ${isOpen ? "absolute left-0 top-0 w-full bg-black bg-opacity-40" : ""}`}
           onAnimationComplete={handleAnimationComplete}
         >
           <UI.NavigationMenu isVisible={isVisible} handleToggle={handleToggle} />

--- a/front/src/components/layouts/mainLayout/index.tsx
+++ b/front/src/components/layouts/mainLayout/index.tsx
@@ -5,7 +5,7 @@ import { Notification } from "@/components/ui";
 
 export default function MainLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="lxgw-wenkai-tc-regular flex min-h-screen flex-col bg-sky-100">
+    <div className="flex min-h-screen flex-col bg-sky-100">
       <header>
         <Layout.Headers />
       </header>

--- a/front/src/components/layouts/top/index.tsx
+++ b/front/src/components/layouts/top/index.tsx
@@ -54,7 +54,7 @@ export default function Top() {
 
   return (
     <Motion.motion.article
-      className={`fixed left-0 top-0 z-50 h-full min-h-screen w-full ${isVisible ? "" : "hidden"}`}
+      className={`fixed left-0 top-0 z-50 h-screen w-screen ${isVisible ? "" : "hidden"}`}
     >
       <Motion.motion.h1
         variants={variantsH1}

--- a/front/src/components/ui/navigationMenu/index.tsx
+++ b/front/src/components/ui/navigationMenu/index.tsx
@@ -82,7 +82,7 @@ export const NavigationMenu = ({
     <motion.div
       id="menuDiv"
       variants={divVariants}
-      className={`fixed left-0 top-0 flex h-full w-full cursor-default flex-col items-center justify-center bg-black bg-opacity-50 ${isVisible ? "" : "hidden"}`}
+      className={`fixed left-0 top-0 z-30 flex h-full w-full cursor-default flex-col items-center justify-center bg-black bg-opacity-50 ${isVisible ? "" : "hidden"}`}
     >
       <motion.ul
         variants={variants}

--- a/front/src/components/ui/navigationMenu/index.tsx
+++ b/front/src/components/ui/navigationMenu/index.tsx
@@ -95,6 +95,13 @@ export const NavigationMenu = ({
           handleToggle={handleToggle}
         />
 
+        {/* 投稿一覧 */}
+        <NavigationMenuItem
+          href={menuItems.posts.href}
+          word={menuItems.posts.word}
+          handleToggle={handleToggle}
+        />
+
         {/* 新規投稿 */}
         {isLogged() && (
           <NavigationMenuItem
@@ -103,13 +110,6 @@ export const NavigationMenu = ({
             handleToggle={handleToggle}
           />
         )}
-
-        {/* 投稿一覧 */}
-        <NavigationMenuItem
-          href={menuItems.posts.href}
-          word={menuItems.posts.word}
-          handleToggle={handleToggle}
-        />
 
         {isLogged() && (
           <>

--- a/front/src/components/ui/navigationMenu/index.tsx
+++ b/front/src/components/ui/navigationMenu/index.tsx
@@ -37,7 +37,7 @@ const menuItems = {
   },
   posts: {
     href: Routes.posts,
-    word: "届いた手紙",
+    word: "みんなの手紙",
   },
   user: (uuid: string) => ({
     href: Routes.user(uuid),

--- a/front/src/components/ui/navigationMenuToggle/index.tsx
+++ b/front/src/components/ui/navigationMenuToggle/index.tsx
@@ -14,7 +14,7 @@ export const NavigationMenuToggle = ({
 }) => (
   <button
     onClick={toggle}
-    className="fixed bottom-0 right-0 m-4 flex items-center justify-center rounded-full bg-sky-300 p-2 md:bottom-auto md:top-0"
+    className="fixed bottom-0 right-0 z-30 m-4 flex items-center justify-center rounded-full bg-sky-300 p-2 md:bottom-auto md:top-0"
   >
     <svg width="30" height="30" viewBox="0 0 24 24">
       <Path


### PR DESCRIPTION
## 概要
投稿一覧の画面を作成しました。

## 紐づく issue
close #12 

## チェック項目
- [x] 各投稿の1枚目の序文がパット見で読めること
- [x] 1投稿あたり何枚投函されているかざっくりわかること
- [ ] 各投稿の1枚目のジャンルやタグが表示されていること
  ⇨ モーダルで表示
- [ ] 検索窓があること
   ⇨ 余力があったら追加するため別issueで対応。
- [ ] 検索ボタンを押すと検索される挙動をすること
   ⇨ 余力があったら追加するため別issueで対応。
- [ ] ジャンルやタグのボタンを押すと検索される挙動をすること
   ⇨ 余力があったら追加するため別issueで対応。

1投稿をクリックした時の挙動
- [x] ポップアップされること
   ⇨ 「どんな手紙？」でモーダル表示。ホバーでアニメーション
- [ ] 1枚目の前半あるいは1000文字程度読めること
   ⇨ ジャンルやタグのみ表示とし、序文は一覧画面でのみ
- [ ] 1投稿あたりに投函している全員の名前が表示されること
   ⇨ ジャンルやタグのみ表示とし、名前は一通目のみ一覧で表示
- [x] 1投稿あたりにつけられているジャンルが全て表示されること
- [ ] ジャンルをクリックするとジャンル検索される挙動をすること
   ⇨ 余力があったら追加するため別issueで対応。
- [x] 1投稿あたりにつけられているタグが全て表示されること
- [ ] タグをクリックするとタグ検索される挙動をすること
   ⇨ 余力があったら追加するため別issueで対応。
- [x] 続きを読むリンクで続きを見に行ける⇨詳細ページへ遷移すること（実装の順番的に遷移実装はまだで良い）
- [x] クローズボタンを押すかポップアップ外を押すと閉じること

### 未実装の項目
- [ ] 各投稿の1枚目のジャンルやタグが表示されていること
  ⇨ モーダルで表示
- [ ] 検索窓があること
   ⇨ 余力があったら追加するため別issueで対応。
- [ ] 検索ボタンを押すと検索される挙動をすること
   ⇨ 余力があったら追加するため別issueで対応。
- [ ] ジャンルやタグのボタンを押すと検索される挙動をすること
   ⇨ 余力があったら追加するため別issueで対応。

1投稿をクリックした時の挙動
- [ ] 1枚目の前半あるいは1000文字程度読めること
   ⇨ ジャンルやタグのみ表示とし、序文は一覧画面でのみ
- [ ] 1投稿あたりに投函している全員の名前が表示されること
   ⇨ ジャンルやタグのみ表示とし、名前は一通目のみ一覧で表示
- [ ] ジャンルをクリックするとジャンル検索される挙動をすること
   ⇨ 余力があったら追加するため別issueで対応。
- [ ] タグをクリックするとタグ検索される挙動をすること
   ⇨ 余力があったら追加するため別issueで対応。

## 挙動
全体挙動
| PC | SP |
| --- | --- |
| <img src="https://i.gyazo.com/06393e115332ec91056e30ad30ab09e7.gif" width="500px" /> | <img src="https://i.gyazo.com/ec5cfb49caed7d8ea674920e10789ca7.gif" width="170px" /> |

モーダル
| PC | SP |
| --- | --- |
| <img src="https://i.gyazo.com/24e0b7cc0e378994e4d7c05d05fb0069.png" width="400px" /> | <img src="https://i.gyazo.com/58830d3cbb8ccbfb54d86e907ff16f98.png" width="170px" /> |

## 補足
もっとissueを細かく分けましょう

## 参考
[どうやって作った？！ レベルのおしゃれカードデザインをコピペで実装！ 【 HTML/CSS 】](https://deshinon.com/2019/03/03/osyare-desing-card/)
