### PR TITLE
【feature】投稿一覧を取得 close #11

### DIFF
--- a/back/app/controllers/api/v1/bases_controller.rb
+++ b/back/app/controllers/api/v1/bases_controller.rb
@@ -1,3 +1,4 @@
 class Api::V1::BasesController < ApplicationController
   include DeviseTokenAuth::Concerns::SetUserByToken
+  before_action :authenticate_api_v1_user!
 end

--- a/back/app/controllers/api/v1/genres_controller.rb
+++ b/back/app/controllers/api/v1/genres_controller.rb
@@ -1,8 +1,8 @@
-class Api::V1::GenresController < ApplicationController
-  skip_before_action :authenticate_user!, only: %i[index]
+class Api::V1::GenresController < Api::V1::BasesController
+  skip_before_action :authenticate_api_v1_user!, only: %i[show]
   
-  def index
-    genres = Post.includes(:genres).find_by(uuid: params[:post_uuid]).genres.map(&:name)
+  def show
+    genres = Post.includes(:genres).find_by(uuid: params[:id]).genres.map(&:name)
 
     render json: genres, status: :ok
   end

--- a/back/app/controllers/api/v1/genres_controller.rb
+++ b/back/app/controllers/api/v1/genres_controller.rb
@@ -1,0 +1,9 @@
+class Api::V1::GenresController < ApplicationController
+  skip_before_action :authenticate_user!, only: %i[index]
+  
+  def index
+    genres = Post.includes(:genres).find_by(uuid: params[:post_uuid]).genres.map(&:name)
+
+    render json: genres, status: :ok
+  end
+end

--- a/back/app/controllers/api/v1/letters_controller.rb
+++ b/back/app/controllers/api/v1/letters_controller.rb
@@ -13,12 +13,12 @@ class Api::V1::LettersController < Api::V1::BasesController
       # タグの登録
       post.create_tags!(letter_params[:tags])
 
-      letter.post = post
+      post.letters << letter
 
-      if letter.save
+      if post.save
       render json: { success: true, message: "投函しました" }, status: :created
       else
-      render json: { success: false, message: "投函できませんした" }, status: :internal_server_error
+      render json: { success: false,  message: post.errors.full_messages.join(", ")}, status: :internal_server_error
       raise ActiveRecord::Rollback
       end
     end

--- a/back/app/controllers/api/v1/posts_controller.rb
+++ b/back/app/controllers/api/v1/posts_controller.rb
@@ -1,5 +1,10 @@
 class Api::V1::PostsController < Api::V1::BasesController
-  def index; end
+  skip_before_action :authenticate_user!, only: %i[index show]
+
+  def index
+    posts = Post.includes(:user, :genres, :tags, :letters).all
+    render json: posts.map(&:as_custom_index_json), status: :ok
+  end
 
   def show; end
 end

--- a/back/app/controllers/api/v1/posts_controller.rb
+++ b/back/app/controllers/api/v1/posts_controller.rb
@@ -1,10 +1,17 @@
 class Api::V1::PostsController < Api::V1::BasesController
-  skip_before_action :authenticate_user!, only: %i[index show]
+  skip_before_action :authenticate_api_v1_user!, only: %i[index show]
 
   def index
-    posts = Post.includes(:user, :genres, :tags, :letters).all
-    render json: posts.map(&:as_custom_index_json), status: :ok
+    posts = Post.includes(:genres, :tags, letters: :user).order(created_at: :desc)
+    posts_paginated = posts.per_page(search_params[:page])
+    render json: posts_paginated.map(&:as_custom_index_json), status: :ok
   end
 
   def show; end
+
+  private
+
+  def search_params
+    params.permit(:page)
+  end
 end

--- a/back/app/controllers/api/v1/posts_controller.rb
+++ b/back/app/controllers/api/v1/posts_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::PostsController < Api::V1::BasesController
   def index
     posts = Post.includes(:genres, :tags, letters: :user).order(created_at: :desc)
     posts_paginated = posts.per_page(search_params[:page])
-    render json: posts_paginated.map(&:as_custom_index_json), status: :ok
+    render json: { posts: posts_paginated.map(&:as_custom_index_json), all_count: Post.all.count }, status: :ok
   end
 
   def show; end

--- a/back/app/controllers/api/v1/tags_controller.rb
+++ b/back/app/controllers/api/v1/tags_controller.rb
@@ -1,0 +1,8 @@
+class Api::V1::TagsController < ApplicationController
+  skip_before_action :authenticate_user!, only: %i[index]
+
+  def index
+    tags = Post.includes(:tags).find_by(uuid: params[:post_uuid]).tags.map(&:name)
+    render json: tags, status: :ok
+  end
+end

--- a/back/app/controllers/api/v1/tags_controller.rb
+++ b/back/app/controllers/api/v1/tags_controller.rb
@@ -1,8 +1,8 @@
-class Api::V1::TagsController < ApplicationController
-  skip_before_action :authenticate_user!, only: %i[index]
+class Api::V1::TagsController < Api::V1::BasesController
+  skip_before_action :authenticate_api_v1_user!, only: %i[show]
 
-  def index
-    tags = Post.includes(:tags).find_by(uuid: params[:post_uuid]).tags.map(&:name)
+  def show
+    tags = Post.includes(:tags).find_by(uuid: params[:id]).tags.map(&:name)
     render json: tags, status: :ok
   end
 end

--- a/back/app/models/post.rb
+++ b/back/app/models/post.rb
@@ -36,4 +36,16 @@ class Post < ApplicationRecord
       post_genres.build(genre: genre)
     end
   end
+
+  def as_custom_index_json
+    {
+      uuid: uuid,
+      letters: {
+        name: letters.first.name,
+        sentences: letters.first.sentences.slice(0, 140),
+      },
+      genres: genres.map(&:name),
+      tags: tags.map(&:name),
+    }
+  end
 end

--- a/back/app/models/post.rb
+++ b/back/app/models/post.rb
@@ -1,12 +1,17 @@
 class Post < ApplicationRecord
-  has_many :post_letters, dependent: :destroy
-  has_many :letters, through: :post_letters, source: :letter
+  has_many :letters, dependent: :destroy
   has_many :post_genres, dependent: :destroy
   has_many :genres, through: :post_genres, source: :genre
   has_many :post_tags, dependent: :destroy
   has_many :tags, through: :post_tags, source: :tag
 
   before_validation :set_default_uuid, on: :create
+
+  scope :per_page, ->(pege) {
+    page = page.to_i
+    page = 1 if page < 1 || nil
+    limit(12).offset((page - 1) * 12)
+  }
 
   def set_default_uuid
     new_uuid = SecureRandom.uuid
@@ -40,12 +45,10 @@ class Post < ApplicationRecord
   def as_custom_index_json
     {
       uuid: uuid,
-      letters: {
+      letters: letters.first ? {
         name: letters.first.name,
         sentences: letters.first.sentences.slice(0, 140),
-      },
-      genres: genres.map(&:name),
-      tags: tags.map(&:name),
+      } : {},
     }
   end
 end

--- a/back/app/models/post.rb
+++ b/back/app/models/post.rb
@@ -48,6 +48,7 @@ class Post < ApplicationRecord
       letters: letters.first ? {
         name: letters.first.name,
         sentences: letters.first.sentences.slice(0, 140),
+        count: letters.count,
       } : {},
     }
   end

--- a/back/app/models/post_letter.rb
+++ b/back/app/models/post_letter.rb
@@ -1,4 +1,0 @@
-class PostLetter < ApplicationRecord
-  belongs_to :post
-  belongs_to :letter
-end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -8,6 +8,8 @@ Rails.application.routes.draw do
       resources :posts, only: [:index, :show] do
         member do
           resource :letter, only: [:create]
+          resource :genres, only: [:index]
+          resource :tags, only: [:index]
         end
       end
     end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -8,8 +8,8 @@ Rails.application.routes.draw do
       resources :posts, only: [:index, :show] do
         member do
           resource :letter, only: [:create]
-          resource :genres, only: [:index]
-          resource :tags, only: [:index]
+          resource :genres, only: [:show]
+          resource :tags, only: [:show]
         end
       end
     end

--- a/back/db/migrate/20240610090226_create_post_letters.rb
+++ b/back/db/migrate/20240610090226_create_post_letters.rb
@@ -1,8 +1,0 @@
-class CreatePostLetters < ActiveRecord::Migration[7.1]
-  def change
-    create_table :post_letters do |t|
-      t.references :post, :null => false
-      t.references :letter, :null => false
-    end
-  end
-end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -38,13 +38,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_10_090303) do
     t.index ["post_id"], name: "index_post_genres_on_post_id"
   end
 
-  create_table "post_letters", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint "post_id", null: false
-    t.bigint "letter_id", null: false
-    t.index ["letter_id"], name: "index_post_letters_on_letter_id"
-    t.index ["post_id"], name: "index_post_letters_on_post_id"
-  end
-
   create_table "post_tags", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "post_id", null: false
     t.bigint "tag_id", null: false

--- a/back/db/seeds.rb
+++ b/back/db/seeds.rb
@@ -1,9 +1,21 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
+# user = User.first
+
+# 30.times do |n|
+#   post = Post.new
+#   tag_counts = Random.rand(1..5)
+#   tag_counts.times do |m|
+#     post.tags << Tag.find_or_create_by(name: "タグ#{m}")
 #   end
+
+#   genre_counts = Random.rand(1..5)
+#   genre_counts.times do |m|
+#     post.genres << Genre.find_or_create_by(name: "ジャンル#{m}")
+#   end
+
+#   count = Random.rand(1..10)
+#   count.times do |m|
+#     letter = user.letters.new(name: "名もなき人", sentences: "こんにちは、#{m}回目の手紙です。")
+#     post.letters << letter
+#   end
+#   post.save
+# end


### PR DESCRIPTION
## 概要
投稿一覧を取得する処理を書きました。

## 紐づく issue
close #11 

## チェック項目
- [x] 1枚目の序文（1000文字ほど）
   ⇨ 140文字に減らしました。1000文字もいらなそう
- [x] 1枚目を書いた人の名前
- [ ] 紐づけられているジャンル一覧
   ⇨ 一気に取得するのではなく「どんな手紙？」をクリック時に取得するように変更
- [ ] 紐づけられているタグ一覧
   ⇨ 一気に取得するのではなく「どんな手紙？」をクリック時に取得するように変更
- [x] 何枚投稿されているか
- [x] 詳細ページへのid
- [ ] 続きを書いている人の名前一覧（重複を除く）
   ⇨ そもそも必要か要検討

取得する全体
- [ ] ~~10~~12件取得できること
   ⇨ ブレークポイントごとに1列：2列：3列の表示なので2と3の倍数でちょうど良さそうな12件にしました。

### 未実装の項目

## 挙動
投稿一覧
| PC |
| --- | 
| <img src="https://i.gyazo.com/4648c478485a8fd83d535595ab1a32d1.png" width="400px" /> | 

1投稿でのタグ一覧
| PC |
| --- |
| <img src="https://i.gyazo.com/50e83cfad027298bdc38f16d190ed502.png" width="400px" /> | 

1投稿でのジャンル一覧
| PC |
| --- |
| <img src="https://i.gyazo.com/3d99eb019c0d4ad2f698c091c6c44aa7.png" width="400px" /> | 

## 補足

## 参考
