### PR TITLE
【feature】投稿一覧のデータ取得と表示 close #13

### DIFF
--- a/back/app/controllers/api/v1/posts_controller.rb
+++ b/back/app/controllers/api/v1/posts_controller.rb
@@ -3,15 +3,10 @@ class Api::V1::PostsController < Api::V1::BasesController
 
   def index
     posts = Post.includes(:genres, :tags, letters: :user).order(created_at: :desc)
-    posts_paginated = posts.per_page(search_params[:page])
+    page = params[:page].present? ? params[:page].to_i : 1
+    posts_paginated = posts.per_page(page)
     render json: { posts: posts_paginated.map(&:as_custom_index_json), all_count: Post.all.count }, status: :ok
   end
 
   def show; end
-
-  private
-
-  def search_params
-    params.permit(:page)
-  end
 end

--- a/back/app/models/post.rb
+++ b/back/app/models/post.rb
@@ -7,9 +7,9 @@ class Post < ApplicationRecord
 
   before_validation :set_default_uuid, on: :create
 
-  scope :per_page, ->(pege) {
+  scope :per_page, ->(page) {
     page = page.to_i
-    page = 1 if page < 1 || nil
+    page = 1 if page < 1
     limit(12).offset((page - 1) * 12)
   }
 

--- a/front/src/app/globals.css
+++ b/front/src/app/globals.css
@@ -340,7 +340,7 @@ body {
 .postmark {
   position: relative;
   margin: 0;
-  padding: 10px;
+  padding: 8px;
   width: 50px;
   height: 50px;
   border: 5px double #430;

--- a/front/src/app/posts/page.tsx
+++ b/front/src/app/posts/page.tsx
@@ -18,10 +18,12 @@ export default function Posts() {
   const [opened, { open, close }] = useDisclosure(false);
   const [cnt, setCnt] = useState(1);
   const [currentUuid, setCurrentUuid] = useState<string>("");
+  const [currentLettersCount, setCurrentLettersCount] = useState<number>(0);
 
-  const handleClick = (uuid: string) => {
+  const handleClick = (uuid: string, lettersCount: number) => {
     open();
     setCurrentUuid(uuid);
+    setCurrentLettersCount(lettersCount);
   };
 
   const { data: Tags } = useSWR(`/posts/${currentUuid}/tags`, fetcher);
@@ -29,7 +31,7 @@ export default function Posts() {
 
   const pages = [];
   for (let i = 1; i <= cnt; i++) {
-    pages.push(<Page key={i} index={i} onClick={handleClick} />);
+    pages.push(<Letters key={i} index={i} onClick={handleClick} />);
   }
 
   useEffect(() => {
@@ -59,7 +61,7 @@ export default function Posts() {
       <Modal opened={opened} onClose={close} title="どんな手紙？">
         <div className="relative mt-8 bg-white px-2">
           <h3>
-            <span className="border-b border-sky-600 px-2">ジャンル</span>
+            <span className="border-b border-sky-600 pr-2">ジャンル</span>
           </h3>
           <ul className="border-b border-dashed border-sky-300 pb-2">
             {Genres === undefined ? (
@@ -71,7 +73,7 @@ export default function Posts() {
             )}
           </ul>
           <h3 className="pt-2">
-            <span className="border-b border-sky-600 px-2">タグ</span>
+            <span className="border-b border-sky-600 pr-2">タグ</span>
           </h3>
           <ul>
             {Tags === undefined ? (
@@ -84,7 +86,8 @@ export default function Posts() {
           </ul>
           <div className="absolute bottom-8 right-0 opacity-50">
             <div className="postmark">
-              1<span className="text-sm">通</span>
+              {currentLettersCount}
+              <span className="text-sm">通</span>
             </div>
           </div>
           <div className="text-end">
@@ -101,7 +104,13 @@ export default function Posts() {
   );
 }
 
-function Page({ index, onClick }: { index: number; onClick: (uuid: string) => void }) {
+function Letters({
+  index,
+  onClick,
+}: {
+  index: number;
+  onClick: (uuid: string, lettersCount: number) => void;
+}) {
   const { data } = useSWR(`/posts?page=${index}`, fetcher);
 
   if (!data) {
@@ -131,7 +140,7 @@ function Page({ index, onClick }: { index: number; onClick: (uuid: string) => vo
             <button
               type="button"
               className="stripe-pattern-sky px-2 text-slate-700"
-              onClick={() => onClick(uuid)}
+              onClick={() => onClick(uuid, letters.count)}
             >
               どんな手紙？
             </button>

--- a/front/src/app/posts/page.tsx
+++ b/front/src/app/posts/page.tsx
@@ -3,386 +3,57 @@
 import { Modal } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import Link from "next/link";
+import { useEffect, useState } from "react";
+import useSWR from "swr";
+
+import { Routes } from "@/config";
+import { axiosClient } from "@/lib";
+
+const fetcher = (url: string) =>
+  axiosClient()
+    .get(url)
+    .then((res) => res.data);
 
 export default function Posts() {
   const [opened, { open, close }] = useDisclosure(false);
+  const [cnt, setCnt] = useState(1);
+  const [currentUuid, setCurrentUuid] = useState<string>("");
+
+  const handleClick = (uuid: string) => {
+    open();
+    setCurrentUuid(uuid);
+  };
+
+  const { data: Tags } = useSWR(`/posts/${currentUuid}/tags`, fetcher);
+  const { data: Genres } = useSWR(`/posts/${currentUuid}/genres`, fetcher);
+
+  const pages = [];
+  for (let i = 1; i <= cnt; i++) {
+    pages.push(<Page key={i} index={i} onClick={handleClick} />);
+  }
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const { scrollHeight, clientHeight, scrollTop } = document.documentElement;
+      const isScrolledToBottom = scrollHeight - scrollTop === clientHeight;
+      if (isScrolledToBottom) {
+        setCnt((prev) => prev + 1);
+      }
+    };
+
+    window.addEventListener("scroll", handleScroll);
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, []);
 
   return (
     <>
       <article className="container relative m-auto">
         <h1 className="text-center text-xl">みんなの手紙</h1>
         <div className="my-12 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3">
-          {/* ここから手紙 */}
-          <section className="envelope-container group">
-            <div className="envelope envelope1 relative">
-              <div className="card absolute overflow-hidden">
-                <div className="absolute top-0 z-20 whitespace-pre-wrap p-4 text-sm">
-                  ダミーテキストダミーテキストダミーテキストダミーテキストダミーテキスト
-                </div>
-              </div>
-              <div className="absolute -left-[140px] top-[230px] z-10 flex w-[280px] flex-col items-start justify-center gap-3 text-sm">
-                <button
-                  type="button"
-                  className="stripe-pattern-sky px-2 text-slate-700"
-                  onClick={open}
-                >
-                  どんな手紙？
-                </button>
-                <Link href="" className="stripe-pattern-orange px-2 text-slate-700">
-                  手紙を読む
-                </Link>
-              </div>
-              <div className="absolute -right-[120px] top-[200px] z-10 flex flex-col items-start justify-center gap-3 text-sm">
-                <div className="postmark">
-                  1<span className="text-sm">通</span>
-                </div>
-              </div>
-              <div className="absolute -right-[140px] top-[275px] z-10 flex w-[180px] flex-col items-start justify-center gap-3 text-end text-sm">
-                <p className="w-full">ダミーユーザー より</p>
-              </div>
-            </div>
-            <div className="envelope envelope2 relative">
-              <div className="card absolute"></div>
-            </div>
-            <div className="envelope envelope3 relative">
-              <div className="card absolute"></div>
-            </div>
-            <div className="envelope envelope4 relative">
-              <div className="card absolute"></div>
-            </div>
-            <div className="envelope envelope5 relative">
-              <div className="card absolute"></div>
-            </div>
-          </section>
-          {/* ここまで手紙 */}
-          <section className="envelope-container group">
-            <div className="envelope envelope1 relative">
-              <div className="card absolute overflow-hidden">
-                <div className="absolute top-0 z-20 whitespace-pre-wrap p-4 text-sm">
-                  ダミーテキストダミーテキストダミーテキストダミーテキストダミーテキスト
-                </div>
-              </div>
-              <div className="absolute -left-[140px] top-[230px] z-10 flex w-[280px] flex-col items-start justify-center gap-3 text-sm">
-                <button
-                  type="button"
-                  className="stripe-pattern-sky px-2 text-slate-700"
-                  onClick={open}
-                >
-                  どんな手紙？
-                </button>
-                <Link href="" className="stripe-pattern-orange px-2 text-slate-700">
-                  手紙を読む
-                </Link>
-              </div>
-              <div className="absolute -right-[120px] top-[200px] z-10 flex flex-col items-start justify-center gap-3 text-sm">
-                <div className="postmark">
-                  1<span className="text-sm">通</span>
-                </div>
-              </div>
-              <div className="absolute -right-[140px] top-[275px] z-10 flex w-[180px] flex-col items-start justify-center gap-3 text-end text-sm">
-                <p className="w-full">ダミーユーザー より</p>
-              </div>
-            </div>
-            <div className="envelope envelope2 relative">
-              <div className="card absolute"></div>
-            </div>
-            <div className="envelope envelope3 relative">
-              <div className="card absolute"></div>
-            </div>
-            <div className="envelope envelope4 relative">
-              <div className="card absolute"></div>
-            </div>
-            <div className="envelope envelope5 relative">
-              <div className="card absolute"></div>
-            </div>
-          </section>
-          <section className="envelope-container group">
-            <div className="envelope envelope1 relative">
-              <div className="card absolute overflow-hidden">
-                <div className="absolute top-0 z-20 whitespace-pre-wrap p-4 text-sm">
-                  ダミーテキストダミーテキストダミーテキストダミーテキストダミーテキスト
-                </div>
-              </div>
-              <div className="absolute -left-[140px] top-[230px] z-10 flex w-[280px] flex-col items-start justify-center gap-3 text-sm">
-                <button
-                  type="button"
-                  className="stripe-pattern-sky px-2 text-slate-700"
-                  onClick={open}
-                >
-                  どんな手紙？
-                </button>
-                <Link href="" className="stripe-pattern-orange px-2 text-slate-700">
-                  手紙を読む
-                </Link>
-              </div>
-              <div className="absolute -right-[120px] top-[200px] z-10 flex flex-col items-start justify-center gap-3 text-sm">
-                <div className="postmark">
-                  1<span className="text-sm">通</span>
-                </div>
-              </div>
-              <div className="absolute -right-[140px] top-[275px] z-10 flex w-[180px] flex-col items-start justify-center gap-3 text-end text-sm">
-                <p className="w-full">ダミーユーザー より</p>
-              </div>
-            </div>
-            <div className="envelope envelope2 relative">
-              <div className="card absolute"></div>
-            </div>
-            <div className="envelope envelope3 relative">
-              <div className="card absolute"></div>
-            </div>
-            <div className="envelope envelope4 relative">
-              <div className="card absolute"></div>
-            </div>
-            <div className="envelope envelope5 relative">
-              <div className="card absolute"></div>
-            </div>
-          </section>
-          <section className="envelope-container group">
-            <div className="envelope envelope1 relative">
-              <div className="card absolute overflow-hidden">
-                <div className="absolute top-0 z-20 whitespace-pre-wrap p-4 text-sm">
-                  ダミーテキストダミーテキストダミーテキストダミーテキストダミーテキスト
-                </div>
-              </div>
-              <div className="absolute -left-[140px] top-[230px] z-10 flex w-[280px] flex-col items-start justify-center gap-3 text-sm">
-                <button
-                  type="button"
-                  className="stripe-pattern-sky px-2 text-slate-700"
-                  onClick={open}
-                >
-                  どんな手紙？
-                </button>
-                <Link href="" className="stripe-pattern-orange px-2 text-slate-700">
-                  手紙を読む
-                </Link>
-              </div>
-              <div className="absolute -right-[120px] top-[200px] z-10 flex flex-col items-start justify-center gap-3 text-sm">
-                <div className="postmark">
-                  1<span className="text-sm">通</span>
-                </div>
-              </div>
-              <div className="absolute -right-[140px] top-[275px] z-10 flex w-[180px] flex-col items-start justify-center gap-3 text-end text-sm">
-                <p className="w-full">ダミーユーザー より</p>
-              </div>
-            </div>
-            <div className="envelope envelope2 relative">
-              <div className="card absolute"></div>
-            </div>
-            <div className="envelope envelope3 relative">
-              <div className="card absolute"></div>
-            </div>
-            <div className="envelope envelope4 relative">
-              <div className="card absolute"></div>
-            </div>
-            <div className="envelope envelope5 relative">
-              <div className="card absolute"></div>
-            </div>
-          </section>
-          <section className="envelope-container group">
-            <div className="envelope envelope1 relative">
-              <div className="card absolute overflow-hidden">
-                <div className="absolute top-0 z-20 whitespace-pre-wrap p-4 text-sm">
-                  ダミーテキストダミーテキストダミーテキストダミーテキストダミーテキスト
-                </div>
-              </div>
-              <div className="absolute -left-[140px] top-[230px] z-10 flex w-[280px] flex-col items-start justify-center gap-3 text-sm">
-                <button
-                  type="button"
-                  className="stripe-pattern-sky px-2 text-slate-700"
-                  onClick={open}
-                >
-                  どんな手紙？
-                </button>
-                <Link href="" className="stripe-pattern-orange px-2 text-slate-700">
-                  手紙を読む
-                </Link>
-              </div>
-              <div className="absolute -right-[120px] top-[200px] z-10 flex flex-col items-start justify-center gap-3 text-sm">
-                <div className="postmark">
-                  1<span className="text-sm">通</span>
-                </div>
-              </div>
-              <div className="absolute -right-[140px] top-[275px] z-10 flex w-[180px] flex-col items-start justify-center gap-3 text-end text-sm">
-                <p className="w-full">ダミーユーザー より</p>
-              </div>
-            </div>
-            <div className="envelope envelope2 relative">
-              <div className="card absolute"></div>
-            </div>
-            <div className="envelope envelope3 relative">
-              <div className="card absolute"></div>
-            </div>
-            <div className="envelope envelope4 relative">
-              <div className="card absolute"></div>
-            </div>
-            <div className="envelope envelope5 relative">
-              <div className="card absolute"></div>
-            </div>
-          </section>
-          <section className="envelope-container group">
-            <div className="envelope envelope1 relative">
-              <div className="card absolute overflow-hidden">
-                <div className="absolute top-0 z-20 whitespace-pre-wrap p-4 text-sm">
-                  ダミーテキストダミーテキストダミーテキストダミーテキストダミーテキスト
-                </div>
-              </div>
-              <div className="absolute -left-[140px] top-[230px] z-10 flex w-[280px] flex-col items-start justify-center gap-3 text-sm">
-                <button
-                  type="button"
-                  className="stripe-pattern-sky px-2 text-slate-700"
-                  onClick={open}
-                >
-                  どんな手紙？
-                </button>
-                <Link href="" className="stripe-pattern-orange px-2 text-slate-700">
-                  手紙を読む
-                </Link>
-              </div>
-              <div className="absolute -right-[120px] top-[200px] z-10 flex flex-col items-start justify-center gap-3 text-sm">
-                <div className="postmark">
-                  1<span className="text-sm">通</span>
-                </div>
-              </div>
-              <div className="absolute -right-[140px] top-[275px] z-10 flex w-[180px] flex-col items-start justify-center gap-3 text-end text-sm">
-                <p className="w-full">ダミーユーザー より</p>
-              </div>
-            </div>
-            <div className="envelope envelope2 relative">
-              <div className="card absolute"></div>
-            </div>
-            <div className="envelope envelope3 relative">
-              <div className="card absolute"></div>
-            </div>
-            <div className="envelope envelope4 relative">
-              <div className="card absolute"></div>
-            </div>
-            <div className="envelope envelope5 relative">
-              <div className="card absolute"></div>
-            </div>
-          </section>
-          <section className="envelope-container group">
-            <div className="envelope envelope1 relative">
-              <div className="card absolute overflow-hidden">
-                <div className="absolute top-0 z-20 whitespace-pre-wrap p-4 text-sm">
-                  ダミーテキストダミーテキストダミーテキストダミーテキストダミーテキスト
-                </div>
-              </div>
-              <div className="absolute -left-[140px] top-[230px] z-10 flex w-[280px] flex-col items-start justify-center gap-3 text-sm">
-                <button
-                  type="button"
-                  className="stripe-pattern-sky px-2 text-slate-700"
-                  onClick={open}
-                >
-                  どんな手紙？
-                </button>
-                <Link href="" className="stripe-pattern-orange px-2 text-slate-700">
-                  手紙を読む
-                </Link>
-              </div>
-              <div className="absolute -right-[120px] top-[200px] z-10 flex flex-col items-start justify-center gap-3 text-sm">
-                <div className="postmark">
-                  1<span className="text-sm">通</span>
-                </div>
-              </div>
-              <div className="absolute -right-[140px] top-[275px] z-10 flex w-[180px] flex-col items-start justify-center gap-3 text-end text-sm">
-                <p className="w-full">ダミーユーザー より</p>
-              </div>
-            </div>
-            <div className="envelope envelope2 relative">
-              <div className="card absolute"></div>
-            </div>
-            <div className="envelope envelope3 relative">
-              <div className="card absolute"></div>
-            </div>
-            <div className="envelope envelope4 relative">
-              <div className="card absolute"></div>
-            </div>
-            <div className="envelope envelope5 relative">
-              <div className="card absolute"></div>
-            </div>
-          </section>
-          <section className="envelope-container group">
-            <div className="envelope envelope1 relative">
-              <div className="card absolute overflow-hidden">
-                <div className="absolute top-0 z-20 whitespace-pre-wrap p-4 text-sm">
-                  ダミーテキストダミーテキストダミーテキストダミーテキストダミーテキスト
-                </div>
-              </div>
-              <div className="absolute -left-[140px] top-[230px] z-10 flex w-[280px] flex-col items-start justify-center gap-3 text-sm">
-                <button
-                  type="button"
-                  className="stripe-pattern-sky px-2 text-slate-700"
-                  onClick={open}
-                >
-                  どんな手紙？
-                </button>
-                <Link href="" className="stripe-pattern-orange px-2 text-slate-700">
-                  手紙を読む
-                </Link>
-              </div>
-              <div className="absolute -right-[120px] top-[200px] z-10 flex flex-col items-start justify-center gap-3 text-sm">
-                <div className="postmark">
-                  1<span className="text-sm">通</span>
-                </div>
-              </div>
-              <div className="absolute -right-[140px] top-[275px] z-10 flex w-[180px] flex-col items-start justify-center gap-3 text-end text-sm">
-                <p className="w-full">ダミーユーザー より</p>
-              </div>
-            </div>
-            <div className="envelope envelope2 relative">
-              <div className="card absolute"></div>
-            </div>
-            <div className="envelope envelope3 relative">
-              <div className="card absolute"></div>
-            </div>
-            <div className="envelope envelope4 relative">
-              <div className="card absolute"></div>
-            </div>
-            <div className="envelope envelope5 relative">
-              <div className="card absolute"></div>
-            </div>
-          </section>
-          <section className="envelope-container group">
-            <div className="envelope envelope1 relative">
-              <div className="card absolute overflow-hidden">
-                <div className="absolute top-0 z-20 whitespace-pre-wrap p-4 text-sm">
-                  ダミーテキストダミーテキストダミーテキストダミーテキストダミーテキスト
-                </div>
-              </div>
-              <div className="absolute -left-[140px] top-[230px] z-10 flex w-[280px] flex-col items-start justify-center gap-3 text-sm">
-                <button
-                  type="button"
-                  className="stripe-pattern-sky px-2 text-slate-700"
-                  onClick={open}
-                >
-                  どんな手紙？
-                </button>
-                <Link href="" className="stripe-pattern-orange px-2 text-slate-700">
-                  手紙を読む
-                </Link>
-              </div>
-              <div className="absolute -right-[120px] top-[200px] z-10 flex flex-col items-start justify-center gap-3 text-sm">
-                <div className="postmark">
-                  1<span className="text-sm">通</span>
-                </div>
-              </div>
-              <div className="absolute -right-[140px] top-[275px] z-10 flex w-[180px] flex-col items-start justify-center gap-3 text-end text-sm">
-                <p className="w-full">ダミーユーザー より</p>
-              </div>
-            </div>
-            <div className="envelope envelope2 relative">
-              <div className="card absolute"></div>
-            </div>
-            <div className="envelope envelope3 relative">
-              <div className="card absolute"></div>
-            </div>
-            <div className="envelope envelope4 relative">
-              <div className="card absolute"></div>
-            </div>
-            <div className="envelope envelope5 relative">
-              <div className="card absolute"></div>
-            </div>
-          </section>
+          {pages}
         </div>
       </article>
       <Modal opened={opened} onClose={close} title="どんな手紙？">
@@ -391,21 +62,25 @@ export default function Posts() {
             <span className="border-b border-sky-600 px-2">ジャンル</span>
           </h3>
           <ul className="border-b border-dashed border-sky-300 pb-2">
-            <li>ダミーテキスト</li>
-            <li>ダミーテキスト</li>
-            <li>ダミーテキスト</li>
-            <li>ダミーテキスト</li>
-            <li>ダミーテキスト</li>
+            {Genres === undefined ? (
+              <li>ちょっとまってね</li>
+            ) : Genres?.length === 0 ? (
+              <li>ないみたい</li>
+            ) : (
+              Genres?.map((genre: string) => <li key={genre}>{genre}</li>)
+            )}
           </ul>
           <h3 className="pt-2">
             <span className="border-b border-sky-600 px-2">タグ</span>
           </h3>
           <ul>
-            <li>ダミーテキスト</li>
-            <li>ダミーテキスト</li>
-            <li>ダミーテキスト</li>
-            <li>あいうえお</li>
-            <li>ダミーテキスト</li>
+            {Tags === undefined ? (
+              <li>ちょっとまってね</li>
+            ) : Tags?.length === 0 ? (
+              <li>ないみたい</li>
+            ) : (
+              Tags.map((tag: string) => <li key={tag}>{tag}</li>)
+            )}
           </ul>
           <div className="absolute bottom-8 right-0 opacity-50">
             <div className="postmark">
@@ -413,12 +88,88 @@ export default function Posts() {
             </div>
           </div>
           <div className="text-end">
-            <Link href="" className="stripe-pattern-orange px-2 text-slate-700">
+            <Link
+              href={Routes.post(currentUuid)}
+              className="stripe-pattern-orange px-2 text-slate-700"
+            >
               手紙を読む
             </Link>
           </div>
         </div>
       </Modal>
     </>
+  );
+}
+
+function Page({ index, onClick }: { index: number; onClick: (uuid: string) => void }) {
+  const { data } = useSWR(`/posts?page=${index}`, fetcher);
+
+  if (!data) {
+    return <div>ちょっとまってね</div>;
+  }
+
+  return data.posts.map(
+    ({
+      uuid,
+      letters,
+    }: {
+      uuid: string;
+      letters: {
+        name: string;
+        sentences: string;
+        count: number;
+      };
+    }) => (
+      <section className="envelope-container group" key={uuid}>
+        <div className="envelope envelope1 relative">
+          <div className="card absolute overflow-hidden">
+            <div className="absolute top-0 z-20 whitespace-pre-wrap p-4 text-sm">
+              {letters.sentences}
+            </div>
+          </div>
+          <div className="absolute -left-[140px] top-[230px] z-10 flex w-[280px] flex-col items-start justify-center gap-3 text-sm">
+            <button
+              type="button"
+              className="stripe-pattern-sky px-2 text-slate-700"
+              onClick={() => onClick(uuid)}
+            >
+              どんな手紙？
+            </button>
+            <Link href={Routes.post(uuid)} className="stripe-pattern-orange px-2 text-slate-700">
+              手紙を読む
+            </Link>
+          </div>
+          <div className="absolute -right-[120px] top-[200px] z-10 flex flex-col items-start justify-center gap-3 text-sm">
+            <div className="postmark">
+              {letters.count}
+              <span className="text-sm">通</span>
+            </div>
+          </div>
+          <div className="absolute -right-[140px] top-[275px] z-10 flex w-[180px] flex-col items-start justify-center gap-3 text-end text-sm">
+            <p className="w-full">{letters.name} より</p>
+          </div>
+        </div>
+        {letters.count > 1 && (
+          <div className="envelope envelope2 relative">
+            <div className="card absolute"></div>
+          </div>
+        )}
+        {letters.count > 2 && (
+          <div className="envelope envelope3 relative">
+            <div className="card absolute"></div>
+          </div>
+        )}
+        {letters.count > 3 && (
+          <div className="envelope envelope4 relative">
+            <div className="card absolute"></div>
+          </div>
+        )}
+        {letters.count > 4 && (
+          <div className="envelope envelope5 relative">
+            <div className="card absolute"></div>
+          </div>
+        )}
+      </section>
+    ),
   );
 }

--- a/front/tailwind.config.ts
+++ b/front/tailwind.config.ts
@@ -1,12 +1,15 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
-  content: [
-    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
-  ],
+  content: ["./src/components/**/*.{js,ts,jsx,tsx,mdx}", "./src/app/**/*.{js,ts,jsx,tsx,mdx}"],
   theme: {
-    extend: {},
+    extend: {
+      spacing: {
+        "-140": "-140px",
+        "230": "230px",
+        "280": "280px",
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## 概要
バックから情報を取得しフロントで一覧表示しました。

## 紐づく issue
close #13 

## チェック項目
- [x] 各投稿のデータが表示されていること
- [ ] 検索によるデータの再フェッチが行われること
   ⇨ 検索は別issueにします。

### 未実装の項目
- [ ] 検索によるデータの再フェッチが行われること

## 挙動
| PC | SP |
| --- | --- |
| <img src="https://i.gyazo.com/525c759887044632515993ccf4a5fee4.gif" width="500px" /> | <img src="https://i.gyazo.com/fffa889af4ca40feb4286f356df5ff8b.gif" width="200px" /> |

## 補足
ページネーションの変わりに無限スクロールにしてみました。
触ってみた感触次第ではページネーションにする方向にします。

## 参考
[SWR ページネーション](https://swr.vercel.app/ja/docs/pagination)