### PR TITLE
【feature】詳細ページ画面作成 close #16

### DIFF
--- a/front/src/app/globals.css
+++ b/front/src/app/globals.css
@@ -1,4 +1,3 @@
-@import "@mantine/core/styles.css";
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -135,6 +134,26 @@ body {
 /* ================================== */
 /*            入力フォーム            */
 /* ================================== */
+*:focus-visible {
+  outline: none;
+}
+
+.mantine-TagsInput-pill {
+  background-color: transparent;
+  border-radius: 4px;
+  border: 1px solid #ff8800;
+  color: #ff8800;
+}
+
+.mantine-Pill-label {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* ================================== */
+/*                 UI                 */
+/* ================================== */
 .lined-textarea {
   background-image: repeating-linear-gradient(
       to bottom,
@@ -163,26 +182,34 @@ body {
     0 calc(1.5rem - 1px);
 }
 
-*:focus-visible {
-  outline: none;
+.lined-textarea.leading-7 {
+  background-image: repeating-linear-gradient(
+      to bottom,
+      transparent,
+      transparent calc(1.75rem - 1px),
+      #bae6fd calc(1.75rem - 1px),
+      #bae6fd 1.75rem
+    ),
+    linear-gradient(
+      to right,
+      #bae6fd 0%,
+      #bae6fd 25%,
+      transparent 25%,
+      transparent 50%,
+      #bae6fd 50%,
+      #bae6fd 75%,
+      transparent 75%,
+      transparent 100%
+    );
+  background-size:
+    100% 1.75rem,
+    10px 1px;
+  background-repeat: repeat-y, repeat-x;
+  background-position:
+    0 0,
+    0 calc(1.75rem - 1px);
 }
 
-.mantine-TagsInput-pill {
-  background-color: transparent;
-  border-radius: 4px;
-  border: 1px solid #ff8800;
-  color: #ff8800;
-}
-
-.mantine-Pill-label {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-/* ================================== */
-/*                 UI                 */
-/* ================================== */
 .stripe-pattern-sky,
 .mantine-Modal-header {
   position: relative;
@@ -212,6 +239,13 @@ body {
   transform: translateX(-4px) translateY(3px) rotateZ(-5deg);
 }
 
+.mantine-Modal-body {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  position: relative;
+  padding-bottom: 0;
+}
+
 .mantine-Modal-content {
   border-radius: 0%;
 }
@@ -219,7 +253,6 @@ body {
 /* ================================== */
 /*                手紙                */
 /* ================================== */
-
 .envelope-container {
   display: flex;
   justify-content: center;
@@ -355,4 +388,14 @@ body {
   -ms-transform: rotate(16deg);
   transform: rotate(16deg);
   white-space: nowrap;
+}
+
+.letter-detail {
+  min-height: calc(100vh - 11.5rem);
+}
+
+@media (min-width: 768px) {
+  .letter-detail {
+    min-height: calc(100vh - 13.5rem);
+  }
 }

--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -1,4 +1,6 @@
+import "@mantine/core/styles.css";
 import "./globals.css";
+
 import * as Layouts from "@/components/layouts";
 import * as Provider from "@/provider";
 

--- a/front/src/app/posts/[id]/page.tsx
+++ b/front/src/app/posts/[id]/page.tsx
@@ -1,9 +1,86 @@
-export default function Post() {
+"use client";
+
+import { Pagination } from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
+import Link from "next/link";
+import { useState } from "react";
+// import useSWR from "swr";
+
+import { Routes } from "@/config";
+import { DetailModal } from "@/features/posts";
+// import { axiosClient } from "@/lib";
+
+// const fetcher = (url: string) =>
+//   axiosClient()
+//     .get(url)
+//     .then((res) => res.data);
+
+export default function Post({ params }: { params: { id: string } }) {
+  const { id } = params;
+  const [opened, { open, close }] = useDisclosure(false);
+  const [page, setPage] = useState(1);
+  // const { data, error } = useSWR(`/posts/${id}?page=${page}`, fetcher);
+
+  const data = {
+    letter: {
+      name: "name",
+      created_at: "created_at",
+      sentences: "sentences",
+    },
+    pages: 1,
+    count: 1,
+  };
+
+  const onChange = (value: number) => {
+    setPage(value);
+  };
+
   return (
-    <article>
-      <section>
-        <h1>投稿詳細</h1>
-      </section>
-    </article>
+    <>
+      <article className="letter-detail container m-auto flex flex-col items-center justify-center">
+        <div className="w-full max-w-[800px] flex-grow">
+          <h1 className="text-center text-xl">とある手紙の物語</h1>
+          <section className="py-2">
+            <button type="button" onClick={open} className="stripe-pattern-sky">
+              どんな手紙？
+            </button>
+          </section>
+          {data === undefined ? (
+            <p>ちょっとまってね</p>
+          ) : (
+            <section className="m-auto my-2 bg-white p-4 px-8">
+              <p className="border-b border-sky-200 text-end">{data.letter.name} より</p>
+              <p className="border-b border-sky-200 pt-1 text-end text-sm text-gray-400">
+                {data.letter.created_at}
+              </p>
+              <p className="lined-textarea whitespace-pre-wrap leading-7">
+                {data.letter.sentences}
+              </p>
+            </section>
+          )}
+          <section className="mb-4 mt-2">
+            <div className="m-auto flex w-full items-center justify-between gap-4 px-4">
+              <Link href={Routes.posts} className="rounded bg-slate-500 px-2 py-1 text-white">
+                一覧に戻る
+              </Link>{" "}
+              <Link href={Routes.reply(id)} className="rounded bg-sky-500 px-2 py-1 text-white">
+                返信する
+              </Link>
+            </div>
+          </section>
+        </div>
+        <div className="pagination bottom-0 left-0 m-auto flex w-full max-w-[500px] items-center justify-center rounded bg-sky-200 bg-opacity-50 p-4">
+          <Pagination
+            withEdges
+            total={data.pages}
+            siblings={1}
+            defaultValue={1}
+            value={page}
+            onChange={onChange}
+          />
+        </div>
+      </article>
+      <DetailModal opened={opened} onClose={close} uuid={id} lettersCount={data.count} />
+    </>
   );
 }

--- a/front/src/app/posts/page.tsx
+++ b/front/src/app/posts/page.tsx
@@ -1,18 +1,13 @@
 "use client";
 
-import { Modal } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import useSWR from "swr";
 
 import { Routes } from "@/config";
+import { DetailModal } from "@/features/posts";
 import { axiosClient } from "@/lib";
-
-const fetcher = (url: string) =>
-  axiosClient()
-    .get(url)
-    .then((res) => res.data);
 
 export default function Posts() {
   const [opened, { open, close }] = useDisclosure(false);
@@ -25,9 +20,6 @@ export default function Posts() {
     setCurrentUuid(uuid);
     setCurrentLettersCount(lettersCount);
   };
-
-  const { data: Tags } = useSWR(`/posts/${currentUuid}/tags`, fetcher);
-  const { data: Genres } = useSWR(`/posts/${currentUuid}/genres`, fetcher);
 
   const pages = [];
   for (let i = 1; i <= cnt; i++) {
@@ -58,51 +50,21 @@ export default function Posts() {
           {pages}
         </div>
       </article>
-      <Modal opened={opened} onClose={close} title="どんな手紙？">
-        <div className="relative mt-8 bg-white px-2">
-          <h3>
-            <span className="border-b border-sky-600 pr-2">ジャンル</span>
-          </h3>
-          <ul className="border-b border-dashed border-sky-300 pb-2">
-            {Genres === undefined ? (
-              <li>ちょっとまってね</li>
-            ) : Genres?.length === 0 ? (
-              <li>ないみたい</li>
-            ) : (
-              Genres?.map((genre: string) => <li key={genre}>{genre}</li>)
-            )}
-          </ul>
-          <h3 className="pt-2">
-            <span className="border-b border-sky-600 pr-2">タグ</span>
-          </h3>
-          <ul>
-            {Tags === undefined ? (
-              <li>ちょっとまってね</li>
-            ) : Tags?.length === 0 ? (
-              <li>ないみたい</li>
-            ) : (
-              Tags.map((tag: string) => <li key={tag}>{tag}</li>)
-            )}
-          </ul>
-          <div className="absolute bottom-8 right-0 opacity-50">
-            <div className="postmark">
-              {currentLettersCount}
-              <span className="text-sm">通</span>
-            </div>
-          </div>
-          <div className="text-end">
-            <Link
-              href={Routes.post(currentUuid)}
-              className="stripe-pattern-orange px-2 text-slate-700"
-            >
-              手紙を読む
-            </Link>
-          </div>
-        </div>
-      </Modal>
+      <DetailModal
+        opened={opened}
+        onClose={close}
+        uuid={currentUuid}
+        lettersCount={currentLettersCount}
+        isReadLetter={true}
+      />
     </>
   );
 }
+
+const fetcher = (url: string) =>
+  axiosClient()
+    .get(url)
+    .then((res) => res.data);
 
 function Letters({
   index,

--- a/front/src/features/posts/detailModal/index.tsx
+++ b/front/src/features/posts/detailModal/index.tsx
@@ -1,0 +1,75 @@
+import { Modal } from "@mantine/core";
+import Link from "next/link";
+import useSWR from "swr";
+
+import { Routes } from "@/config";
+import { axiosClient } from "@/lib";
+
+const fetcher = (url: string) =>
+  axiosClient()
+    .get(url)
+    .then((res) => res.data);
+
+export default function DetailModal({
+  opened,
+  onClose,
+  uuid,
+  lettersCount,
+  isReadLetter,
+}: {
+  opened: boolean;
+  onClose: () => void;
+  uuid: string;
+  lettersCount: number;
+  isReadLetter?: boolean;
+}) {
+  const { data: Tags } = useSWR(`/posts/${uuid}/tags`, fetcher);
+  const { data: Genres } = useSWR(`/posts/${uuid}/genres`, fetcher);
+
+  return (
+    <Modal opened={opened} onClose={onClose} title="どんな手紙？">
+      <div className="relative bg-white px-2">
+        <h3 className="my-2 text-lg">
+          <span className="border-b border-sky-600 pr-2">ジャンル</span>
+        </h3>
+        <ul className="pb-2">
+          {Genres === undefined ? (
+            <li>ちょっとまってね</li>
+          ) : Genres?.length === 0 ? (
+            <li>ないみたい</li>
+          ) : (
+            Genres?.map((genre: string) => <li key={genre}>{genre}</li>)
+          )}
+        </ul>
+        <div className="mb-4 w-1/2 border-b border-dashed border-sky-200 pt-4"></div>
+        <h3 className="my-2 text-lg">
+          <span className="border-b border-sky-600 pr-2">タグ</span>
+        </h3>
+        <ul>
+          {Tags === undefined ? (
+            <li>ちょっとまってね</li>
+          ) : Tags?.length === 0 ? (
+            <li>ないみたい</li>
+          ) : (
+            Tags.map((tag: string) => <li key={tag}>{tag}</li>)
+          )}
+        </ul>
+        <div className="absolute bottom-0 right-0 flex flex-col items-end justify-center gap-3">
+          <div className="opacity-50">
+            <div className="postmark">
+              {lettersCount}
+              <span className="text-sm">通</span>
+            </div>
+          </div>
+          {isReadLetter && (
+            <div className="text-end">
+              <Link href={Routes.post(uuid)} className="stripe-pattern-orange px-2 text-slate-700">
+                手紙を読む
+              </Link>
+            </div>
+          )}
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/front/src/features/posts/index.ts
+++ b/front/src/features/posts/index.ts
@@ -1,3 +1,4 @@
+import DetailModal from "./detailModal";
 import NewLetter from "./newLetter";
 
-export { NewLetter };
+export { NewLetter, DetailModal };


### PR DESCRIPTION
## 概要
投稿詳細ページの画面を作成しました。

## 紐づく issue
close #16 

## チェック項目
- [x] 1手紙あたりの内容
   - [x] 投稿本文
   - [x] 投稿者名（ユーザー名とは別）
   - [x] ジャンル：スタンプ風
      ⇨ デザインは後回し
   - [x] タグ：シール風
      ⇨ デザインは後回し
   - [x] 投稿日時：消印風
      ⇨ デザインは後回し
- [x] 全体の内容
   - 次の手紙があるときは次の手紙をめくるボタン：次の手紙が表示されます。
      ⇨ ページネーション対応
   - 前の手紙があるときは前の手紙をめくるボタン：前の手紙が表示されます。
      ⇨ ページネーション対応
   - 最後の手紙のときは「返信する」ボタン：投稿ページ（返信用）へ遷移します。ログイン限定機能です。
      ⇨ 最後のページでなくても表示します
   - 一覧へ戻るボタン：投稿一覧へ遷移します。
   - いいねボタン：いいね・いいね解除ができます。ログイン限定機能です。
      ⇨ いいね機能実装時につけます
   - ブックマークボタン：ブックマーク・ブックマーク解除ができます。ログイン限定機能です。
      ⇨ ブックマーク機能実装時につけます

### 未実装の項目

## 挙動
| PC | SP |
| --- | --- |
| <img src="https://i.gyazo.com/202edbe6fcaf050c93f1199d45e7cacd.png" width="500px" /> | <img src="https://i.gyazo.com/a9bcbe5e7822de27a07635bc7872d56a.png" width="200px" /> |

## 補足
デザインは後回しです

## 参考
