### PR TITLE
【feature】投稿詳細画面表示 close #15

### DIFF
--- a/back/app/controllers/api/v1/posts_controller.rb
+++ b/back/app/controllers/api/v1/posts_controller.rb
@@ -8,5 +8,10 @@ class Api::V1::PostsController < Api::V1::BasesController
     render json: { posts: posts_paginated.map(&:as_custom_index_json), all_count: Post.all.count }, status: :ok
   end
 
-  def show; end
+  def show
+    post = Post.includes(:genres, :tags, letters: :user).find_by(uuid: params[:id])
+    page = params[:page].present? ? params[:page].to_i : 1
+    letter = post.letters.per_page(page).first
+    render json: { tags: post.tags.map(&:name), genres: post.genres.map(&:name) , letter: letter.as_custom_json, all_count: post.letters.count }, status: :ok
+  end
 end

--- a/back/app/controllers/api/v1/posts_controller.rb
+++ b/back/app/controllers/api/v1/posts_controller.rb
@@ -12,6 +12,6 @@ class Api::V1::PostsController < Api::V1::BasesController
     post = Post.includes(:genres, :tags, letters: :user).find_by(uuid: params[:id])
     page = params[:page].present? ? params[:page].to_i : 1
     letter = post.letters.per_page(page).first
-    render json: { tags: post.tags.map(&:name), genres: post.genres.map(&:name) , letter: letter.as_custom_json, all_count: post.letters.count }, status: :ok
+    render json: { letter: letter.as_custom_json, all_count: post.letters.count }, status: :ok
   end
 end

--- a/back/app/controllers/api/v1/posts_controller.rb
+++ b/back/app/controllers/api/v1/posts_controller.rb
@@ -11,7 +11,11 @@ class Api::V1::PostsController < Api::V1::BasesController
   def show
     post = Post.includes(:genres, :tags, letters: :user).find_by(uuid: params[:id])
     page = params[:page].present? ? params[:page].to_i : 1
-    letter = post.letters.per_page(page).first
-    render json: { letter: letter.as_custom_json, all_count: post.letters.count }, status: :ok
+    letter = page <= post.letters.count ? post.letters.per_page(page).first : nil
+    if letter.nil?
+      render json: { letter: nil, all_count: post.letters.count }, status: :ok
+    else
+      render json: { letter: letter.as_custom_json, all_count: post.letters.count }, status: :ok
+    end
   end
 end

--- a/back/app/models/letter.rb
+++ b/back/app/models/letter.rb
@@ -27,6 +27,7 @@ class Letter < ApplicationRecord
     {
       name: name,
       sentences: sentences,
+      created_at: created_at.strftime('%Y/%m/%d %H:%M'),
     }
   end
 end

--- a/back/app/models/letter.rb
+++ b/back/app/models/letter.rb
@@ -7,6 +7,12 @@ class Letter < ApplicationRecord
   before_validation :set_default_uuid, on: :create
   before_validation :set_default_name, on: :create
 
+  scope :per_page, ->(page) {
+    page = page.to_i
+    page = 1 if page < 1
+    limit(1).offset((page - 1))
+  }
+
   def set_default_uuid
     new_uuid = SecureRandom.uuid
     encode_uuid = Base64.urlsafe_encode64([new_uuid.delete('-')].pack("H*")).tr('=', '')
@@ -15,5 +21,12 @@ class Letter < ApplicationRecord
 
   def set_default_name
     self.name = "名もなき人"
+  end
+
+  def as_custom_json
+    {
+      name: name,
+      sentences: sentences,
+    }
   end
 end

--- a/front/src/app/globals.css
+++ b/front/src/app/globals.css
@@ -274,7 +274,7 @@ body {
     0 100px 0 0 #e2e2e2,
     0 150px 90px 0 rgba(0, 0, 0, 0.2);
   transform-origin: center;
-  transition: transform 0.5s ease-in-out;
+  transition: transform 0.3s ease-in-out;
   position: absolute;
   top: 0;
   left: 0;
@@ -354,7 +354,7 @@ body {
   z-index: -1;
   background-color: #ffffff;
   border-radius: 5px;
-  transition: transform 0.5s ease-in-out;
+  transition: transform 0.3s ease-in-out;
   text-align: center;
   letter-spacing: 0.06em;
   padding-top: 130px;

--- a/front/src/app/posts/[id]/page.tsx
+++ b/front/src/app/posts/[id]/page.tsx
@@ -3,33 +3,24 @@
 import { Pagination } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import Link from "next/link";
-import { useState } from "react";
-// import useSWR from "swr";
+import { useEffect, useState } from "react";
+import useSWR from "swr";
 
 import { Routes } from "@/config";
 import { DetailModal } from "@/features/posts";
-// import { axiosClient } from "@/lib";
+import { axiosClient } from "@/lib";
 
-// const fetcher = (url: string) =>
-//   axiosClient()
-//     .get(url)
-//     .then((res) => res.data);
+const fetcher = (url: string) =>
+  axiosClient()
+    .get(url)
+    .then((res) => res.data);
 
 export default function Post({ params }: { params: { id: string } }) {
   const { id } = params;
   const [opened, { open, close }] = useDisclosure(false);
   const [page, setPage] = useState(1);
-  // const { data, error } = useSWR(`/posts/${id}?page=${page}`, fetcher);
-
-  const data = {
-    letter: {
-      name: "name",
-      created_at: "created_at",
-      sentences: "sentences",
-    },
-    pages: 1,
-    count: 1,
-  };
+  const [pageCount, setPageCount] = useState(1);
+  // const { data } = useSWR(`/posts/${id}?page=${page}`, fetcher);
 
   const onChange = (value: number) => {
     setPage(value);
@@ -38,41 +29,12 @@ export default function Post({ params }: { params: { id: string } }) {
   return (
     <>
       <article className="letter-detail container m-auto flex flex-col items-center justify-center">
-        <div className="w-full max-w-[800px] flex-grow">
-          <h1 className="text-center text-xl">とある手紙の物語</h1>
-          <section className="py-2">
-            <button type="button" onClick={open} className="stripe-pattern-sky">
-              どんな手紙？
-            </button>
-          </section>
-          {data === undefined ? (
-            <p>ちょっとまってね</p>
-          ) : (
-            <section className="m-auto my-2 bg-white p-4 px-8">
-              <p className="border-b border-sky-200 text-end">{data.letter.name} より</p>
-              <p className="border-b border-sky-200 pt-1 text-end text-sm text-gray-400">
-                {data.letter.created_at}
-              </p>
-              <p className="lined-textarea whitespace-pre-wrap leading-7">
-                {data.letter.sentences}
-              </p>
-            </section>
-          )}
-          <section className="mb-4 mt-2">
-            <div className="m-auto flex w-full items-center justify-between gap-4 px-4">
-              <Link href={Routes.posts} className="rounded bg-slate-500 px-2 py-1 text-white">
-                一覧に戻る
-              </Link>{" "}
-              <Link href={Routes.reply(id)} className="rounded bg-sky-500 px-2 py-1 text-white">
-                返信する
-              </Link>
-            </div>
-          </section>
-        </div>
+        {Letter({ open, page, uuid: id, setPageCount })}
+        <div style={{ display: "none" }}>{Letter({ open, page: page + 1, uuid: id })}</div>
         <div className="pagination bottom-0 left-0 m-auto flex w-full max-w-[500px] items-center justify-center rounded bg-sky-200 bg-opacity-50 p-4">
           <Pagination
             withEdges
-            total={data.pages}
+            total={pageCount}
             siblings={1}
             defaultValue={1}
             value={page}
@@ -80,7 +42,62 @@ export default function Post({ params }: { params: { id: string } }) {
           />
         </div>
       </article>
-      <DetailModal opened={opened} onClose={close} uuid={id} lettersCount={data.count} />
+      <DetailModal opened={opened} onClose={close} uuid={id} lettersCount={pageCount} />
     </>
+  );
+}
+
+function Letter({
+  open,
+  page,
+  uuid,
+  setPageCount,
+}: {
+  open: () => void;
+  page: number;
+  uuid: string;
+  setPageCount?: (value: number) => void;
+}) {
+  const { data } = useSWR(`/posts/${uuid}?page=${page}`, fetcher);
+
+  useEffect(() => {
+    if (data && setPageCount) {
+      setPageCount(data.all_count);
+    }
+  }, [data, setPageCount]);
+
+  if (data === undefined) {
+    return <p>ちょっとまってね</p>;
+  }
+  return (
+    <div className="w-full max-w-[800px] flex-grow">
+      <h1 className="text-center text-xl">とある手紙の物語</h1>
+      <section className="py-2">
+        <button type="button" onClick={open} className="stripe-pattern-sky">
+          どんな手紙？
+        </button>
+      </section>
+      {data === undefined ? (
+        <p>ちょっとまってね</p>
+      ) : (
+        <section className="m-auto my-2 bg-white p-4 px-8">
+          <p className="border-b border-sky-200 text-end">{data.letter.name} より</p>
+          <p className="border-b border-sky-200 pt-1 text-end text-sm text-gray-400">
+            {data.letter.created_at}
+          </p>
+          <p className="lined-textarea whitespace-pre-wrap leading-7">{data.letter.sentences}</p>
+        </section>
+      )}
+      <section className="mb-4 mt-2">
+        <div className="m-auto flex w-full items-center justify-between gap-4 px-4">
+          <Link href={Routes.posts} className="rounded bg-slate-500 px-2 py-1 text-white">
+            一覧に戻る
+          </Link>{" "}
+          <Link href={Routes.reply(uuid)} className="rounded bg-sky-500 px-2 py-1 text-white">
+            返信する
+          </Link>
+        </div>
+      </section>
+    </div>
   );
 }

--- a/front/src/app/posts/[id]/page.tsx
+++ b/front/src/app/posts/[id]/page.tsx
@@ -24,6 +24,8 @@ export default function Post({ params }: { params: { id: string } }) {
 
   const onChange = (value: number) => {
     setPage(value);
+
+    window.scrollTo({ top: 0, behavior: "smooth" });
   };
 
   return (
@@ -69,6 +71,9 @@ function Letter({
   if (data === undefined) {
     return <p>ちょっとまってね</p>;
   }
+
+  if (data.letter == null) return;
+
   return (
     <div className="w-full max-w-[800px] flex-grow">
       <h1 className="text-center text-xl">とある手紙の物語</h1>

--- a/front/src/features/posts/detailModal/index.tsx
+++ b/front/src/features/posts/detailModal/index.tsx
@@ -23,8 +23,8 @@ export default function DetailModal({
   lettersCount: number;
   isReadLetter?: boolean;
 }) {
-  const { data: Tags } = useSWR(`/posts/${uuid}/tags`, fetcher);
-  const { data: Genres } = useSWR(`/posts/${uuid}/genres`, fetcher);
+  const { data: Tags } = useSWR(uuid ? `/posts/${uuid}/tags` : null, fetcher);
+  const { data: Genres } = useSWR(uuid ? `/posts/${uuid}/genres` : null, fetcher);
 
   return (
     <Modal opened={opened} onClose={onClose} title="どんな手紙？">


### PR DESCRIPTION
## 概要
バックの投稿詳細取得を実装し、フロントと接続しました。
投稿詳細が表示されるようになっています。

## 紐づく issue
close #15 

## チェック項目
- [x] 投稿されている全ての手紙
   - [x] 投稿本文
   - [x] 投稿した名前
   - [x] 紐づいているジャンル
   - [x] 紐づいているタグ
   - [x] 投稿日時

### 未実装の項目

## 挙動
| PC | SP |
| --- | --- |
| <img src="https://i.gyazo.com/010d7c2d63a68fba68323201cdc23db8.gif" width="500px" /> | <img src="https://i.gyazo.com/ac8722c1dec5aa598b0bea137b753f2a.gif" width="200px" /> |

## 補足
とくになし

## 参考
[SWR ページネーション](https://swr.vercel.app/ja/docs/pagination)
