### PR TITLE
【feature】返信機能 close #10

### DIFF
--- a/back/app/controllers/api/v1/letters_controller.rb
+++ b/back/app/controllers/api/v1/letters_controller.rb
@@ -16,10 +16,10 @@ class Api::V1::LettersController < Api::V1::BasesController
       post.letters << letter
 
       if post.save
-      render json: { success: true, message: "投函しました" }, status: :created
+        render json: { success: true, message: "投函しました" }, status: :created
       else
-      render json: { success: false,  message: post.errors.full_messages.join(", ")}, status: :internal_server_error
-      raise ActiveRecord::Rollback
+        render json: { success: false,  message: post.errors.full_messages.join(", ")}, status: :internal_server_error
+        raise ActiveRecord::Rollback
       end
     end
   end

--- a/front/src/app/posts/[id]/page.tsx
+++ b/front/src/app/posts/[id]/page.tsx
@@ -20,7 +20,6 @@ export default function Post({ params }: { params: { id: string } }) {
   const [opened, { open, close }] = useDisclosure(false);
   const [page, setPage] = useState(1);
   const [pageCount, setPageCount] = useState(1);
-  // const { data } = useSWR(`/posts/${id}?page=${page}`, fetcher);
 
   const onChange = (value: number) => {
     setPage(value);
@@ -31,7 +30,25 @@ export default function Post({ params }: { params: { id: string } }) {
   return (
     <>
       <article className="letter-detail container m-auto flex flex-col items-center justify-center">
-        {Letter({ open, page, uuid: id, setPageCount })}
+        <div className="w-full max-w-[800px] flex-grow">
+          <h1 className="text-center text-xl">とある手紙の物語</h1>
+          <section className="py-2">
+            <button type="button" onClick={open} className="stripe-pattern-sky">
+              どんな手紙？
+            </button>
+          </section>
+          {Letter({ open, page, uuid: id, setPageCount })}
+          <section className="mb-4 mt-2">
+            <div className="m-auto flex w-full items-center justify-between gap-4 px-4">
+              <Link href={Routes.posts} className="rounded bg-slate-500 px-2 py-1 text-white">
+                一覧に戻る
+              </Link>{" "}
+              <Link href={Routes.reply(id)} className="rounded bg-sky-500 px-2 py-1 text-white">
+                返信する
+              </Link>
+            </div>
+          </section>
+        </div>
         <div style={{ display: "none" }}>{Letter({ open, page: page + 1, uuid: id })}</div>
         <div className="pagination bottom-0 left-0 m-auto flex w-full max-w-[500px] items-center justify-center rounded bg-sky-200 bg-opacity-50 p-4">
           <Pagination
@@ -50,7 +67,6 @@ export default function Post({ params }: { params: { id: string } }) {
 }
 
 function Letter({
-  open,
   page,
   uuid,
   setPageCount,
@@ -75,13 +91,7 @@ function Letter({
   if (data.letter == null) return;
 
   return (
-    <div className="w-full max-w-[800px] flex-grow">
-      <h1 className="text-center text-xl">とある手紙の物語</h1>
-      <section className="py-2">
-        <button type="button" onClick={open} className="stripe-pattern-sky">
-          どんな手紙？
-        </button>
-      </section>
+    <>
       {data === undefined ? (
         <p>ちょっとまってね</p>
       ) : (
@@ -93,16 +103,6 @@ function Letter({
           <p className="lined-textarea whitespace-pre-wrap leading-7">{data.letter.sentences}</p>
         </section>
       )}
-      <section className="mb-4 mt-2">
-        <div className="m-auto flex w-full items-center justify-between gap-4 px-4">
-          <Link href={Routes.posts} className="rounded bg-slate-500 px-2 py-1 text-white">
-            一覧に戻る
-          </Link>{" "}
-          <Link href={Routes.reply(uuid)} className="rounded bg-sky-500 px-2 py-1 text-white">
-            返信する
-          </Link>
-        </div>
-      </section>
-    </div>
+    </>
   );
 }

--- a/front/src/app/posts/[id]/reply/page.tsx
+++ b/front/src/app/posts/[id]/reply/page.tsx
@@ -1,9 +1,258 @@
-export default function PostReply() {
+"use client";
+
+import { Drawer, Pagination } from "@mantine/core";
+import { useForm } from "@mantine/form";
+import { useDisclosure } from "@mantine/hooks";
+import { motion } from "framer-motion";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import useSWR from "swr";
+
+import * as Form from "@/components/forms";
+import * as UI from "@/components/ui";
+import { Routes } from "@/config";
+import { DetailModal } from "@/features/posts";
+import { ReplyLetter } from "@/features/posts";
+import { useNotification } from "@/hooks";
+import { axiosClient } from "@/lib";
+import { NotificationType } from "@/types";
+
+const fetcher = (url: string) =>
+  axiosClient()
+    .get(url)
+    .then((res) => res.data);
+
+const Genres = ["SF", "ファンタジー", "恋愛", "ホラー", "ミステリー", "サスペンス", "ポエム"];
+
+const Tags = ["涙腺崩壊", "意味怖", "ほのぼの", "切ない", "ハッピー", "感動", "笑い", "おもしろ"];
+
+export default function Reply({ params }: { params: { id: string } }) {
+  const { id } = params;
+  const [opened, { open, close }] = useDisclosure(false);
+  const [openedLetter, { open: openLetter, close: closeLetter }] = useDisclosure(false);
+  const [pageCount, setPageCount] = useState(1);
+  const [page, setPage] = useState(pageCount);
+
+  const onChange = (value: number) => {
+    setPage(value);
+  };
+
+  // TODO : リファクタリング
+  const [isPost, setIsPost] = useState(false);
+  const [isPostAnimationComplete, setIsPostAnimationComplete] = useState(false);
+  const [isPostComplete, setIsPostComplete] = useState(false);
+  const { setNewNotification } = useNotification();
+  const router = useRouter();
+  const MAX_NAME_LENGTH = 10;
+  const MAX_SENTENCE_LENGTH = 100000;
+  const form = useForm({
+    initialValues: {
+      name: "",
+      letter: "",
+      genres: [],
+      tags: [],
+    },
+    validate: {
+      name: (value: string) => {
+        if (value.length > MAX_NAME_LENGTH) {
+          return `名前は${MAX_NAME_LENGTH}文字以内がいいな`;
+        }
+      },
+      letter: (value: string) => {
+        if (value.length > MAX_SENTENCE_LENGTH) {
+          return `${MAX_SENTENCE_LENGTH}文字まで書けるよ`;
+        }
+        if (value.length === 0) {
+          return "まだ何も書かれていないよ";
+        }
+      },
+    },
+  });
+
+  useEffect(() => {
+    if (isPostComplete && isPostAnimationComplete) {
+      setNewNotification({
+        title: "せいこう！",
+        message: "手紙を返信しました",
+        type: NotificationType.SUCCESS,
+      });
+      router.push(Routes.post(id));
+    }
+  }, [isPostComplete, isPostAnimationComplete]);
+
+  const togglePost = () => {
+    setIsPost(!isPost);
+  };
+
+  const handleSubmit = async () => {
+    const { name, letter: letterData, genres, tags } = form.getValues();
+
+    const letter = {
+      letter: {
+        name,
+        sentences: letterData,
+        genres,
+        tags,
+      },
+    };
+
+    try {
+      const res = await ReplyLetter(id, letter);
+      if (!res.status) {
+        throw new Error(res.data);
+      }
+
+      togglePost();
+      setIsPostComplete(true);
+    } catch (error) {
+      console.error(error);
+      setNewNotification({
+        title: "しっぱい...",
+        message: "手紙の投函に失敗しました",
+        type: NotificationType.ERROR,
+      });
+    }
+  };
+
+  const onAnimationComplete = () => {
+    if (!isPost) return;
+    form.reset();
+    setIsPostAnimationComplete(true);
+  };
+
   return (
-    <article>
-      <section>
-        <h1>返信</h1>
-      </section>
-    </article>
+    <>
+      <motion.article
+        initial={{ opacity: 1 }}
+        animate={isPost ? { opacity: 0 } : { opacity: 1 }}
+        className={`letter-detail container m-auto flex flex-col items-center justify-center ${isPostAnimationComplete ? "hidden" : ""}`}
+      >
+        <div className="w-full max-w-[800px] flex-grow">
+          <h1 className="text-center text-xl">手紙の続きの物語</h1>
+          <section className="py-2">
+            <button type="button" onClick={open} className="stripe-pattern-sky">
+              どんな手紙？
+            </button>
+          </section>
+          <form
+            className="my-4 flex w-full flex-col items-center justify-center bg-white p-4"
+            onSubmit={form.onSubmit(handleSubmit)}
+          >
+            <div className="mb-8 mt-4 w-full">
+              <Form.Textarea
+                onChange={form.getInputProps("letter").onChange}
+                value={form.getValues().letter}
+                placeholder="拝復..."
+              />
+            </div>
+
+            <div className="m-0 flex w-full flex-col items-end justify-center border-b border-sky-200">
+              <Form.Input
+                onChange={form.getInputProps("name").onChange}
+                value={form.getValues().name}
+              />
+            </div>
+            <div className="mt-2 w-full">
+              <Form.TagsInput
+                label="ジャンル"
+                placeholder="SF、ファンタジー、恋愛、ホラー、ミステリー"
+                data={Genres}
+                props={form.getInputProps("genres")}
+              />
+            </div>
+            <div className="mt-2 w-full">
+              <Form.TagsInput
+                label="タグ"
+                placeholder="涙腺崩壊、意味怖、ほのぼの、切ない、ハッピー"
+                data={Tags}
+                props={form.getInputProps("tags")}
+              />
+            </div>
+            <div className="mt-4 w-full text-center">
+              <Form.ValidError errorMsg={[form.errors.name, form.errors.letter]} />
+              <Form.Button labelName="投函" />
+            </div>
+          </form>
+          <section className="mb-4 mt-2">
+            <div className="m-auto flex w-full items-center justify-between gap-4 px-4">
+              <Link href={Routes.posts} className="rounded bg-slate-500 px-2 py-1 text-white">
+                一覧に戻る
+              </Link>{" "}
+              <button
+                type="button"
+                onClick={openLetter}
+                className="rounded bg-orange-400 px-2 py-1 text-white"
+              >
+                履歴を見る
+              </button>
+            </div>
+          </section>
+        </div>
+      </motion.article>
+      <Drawer opened={openedLetter} onClose={closeLetter} position="bottom" size="md">
+        {Letter({ open, page: page, uuid: id })}
+        <div style={{ display: "none" }}>
+          {Letter({ open, page: page - 1, uuid: id, setPageCount })}
+        </div>
+        <div className="pagination fixed bottom-0 left-0 m-auto flex w-full max-w-[500px] items-center justify-center rounded bg-sky-200 bg-opacity-50 p-4">
+          <Pagination
+            withEdges
+            total={pageCount}
+            siblings={1}
+            defaultValue={1}
+            value={page}
+            onChange={onChange}
+          />
+        </div>
+      </Drawer>
+      <DetailModal opened={opened} onClose={close} uuid={id} lettersCount={pageCount} />
+      <UI.PostDirection
+        name={form.getValues().name}
+        isPost={isPost}
+        onAnimationComplete={onAnimationComplete}
+      />
+    </>
+  );
+}
+
+function Letter({
+  page,
+  uuid,
+  setPageCount,
+}: {
+  open: () => void;
+  page: number;
+  uuid: string;
+  setPageCount?: (value: number) => void;
+}) {
+  const { data } = useSWR(`/posts/${uuid}?page=${page}`, fetcher);
+
+  useEffect(() => {
+    if (data && setPageCount) {
+      setPageCount(data.all_count);
+    }
+  }, [data, setPageCount]);
+
+  if (data === undefined) {
+    return <p>ちょっとまってね</p>;
+  }
+
+  if (data.letter == null) return;
+
+  return (
+    <>
+      {data === undefined ? (
+        <p>ちょっとまってね</p>
+      ) : (
+        <section className="m-auto my-2 bg-white p-4 px-8">
+          <p className="border-b border-sky-200 text-end">{data.letter.name} より</p>
+          <p className="border-b border-sky-200 pt-1 text-end text-sm text-gray-400">
+            {data.letter.created_at}
+          </p>
+          <p className="lined-textarea whitespace-pre-wrap leading-7">{data.letter.sentences}</p>
+        </section>
+      )}
+    </>
   );
 }

--- a/front/src/app/posts/new/page.tsx
+++ b/front/src/app/posts/new/page.tsx
@@ -77,14 +77,13 @@ export default function PostNew() {
 
     try {
       const res = await NewLetter(letter);
-      if (res.status || res.data.success !== true) {
-        throw new Error(res.data.message);
+      if (!res.status) {
+        throw new Error(res.data);
       }
 
       togglePost();
       setIsPostComplete(true);
     } catch (error) {
-      console.error(error);
       setNewNotification({
         title: "しっぱい...",
         message: "手紙の投函に失敗しました",
@@ -117,6 +116,7 @@ export default function PostNew() {
                 <Form.Textarea
                   onChange={form.getInputProps("letter").onChange}
                   value={form.getValues().letter}
+                  placeholder="拝啓..."
                 />
               </div>
 

--- a/front/src/components/forms/textarea/index.tsx
+++ b/front/src/components/forms/textarea/index.tsx
@@ -3,9 +3,11 @@
 export default function Textarea({
   onChange,
   value,
+  placeholder,
 }: {
   onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
   value: string;
+  placeholder: string;
 }) {
   const MAX_LENGTH = 100000;
   const letterLength = value.length;
@@ -20,7 +22,7 @@ export default function Textarea({
     <>
       <textarea
         className={`lined-textarea h-full w-full resize-none px-2 text-base focus:outline-none ${isLetterLengthValid ? "" : "text-red-400"}`}
-        placeholder="拝啓..."
+        placeholder={placeholder}
         value={value}
         onChange={(e) => {
           resizeTextArea(e);

--- a/front/src/features/posts/index.ts
+++ b/front/src/features/posts/index.ts
@@ -1,4 +1,5 @@
 import DetailModal from "./detailModal";
 import NewLetter from "./newLetter";
+import ReplyLetter from "./reply";
 
-export { NewLetter, DetailModal };
+export { NewLetter, DetailModal, ReplyLetter };

--- a/front/src/features/posts/newLetter/index.tsx
+++ b/front/src/features/posts/newLetter/index.tsx
@@ -10,10 +10,8 @@ export default async function NewLetter(value: {
 }) {
   try {
     const res = await axiosClient().post("/posts/none/letter", value);
-    if (res.status !== 200 || !res.data) {
-      return { status: false, data: res.data };
-    }
-    return { status: true, data: res.data };
+
+    return { status: res.status === 201, data: res.data.message };
   } catch (error) {
     return { status: false };
   }

--- a/front/src/features/posts/reply/index.tsx
+++ b/front/src/features/posts/reply/index.tsx
@@ -1,0 +1,21 @@
+import { axiosClient } from "@/lib";
+
+export default async function ReplyLetter(
+  uuid: string,
+  value: {
+    letter: {
+      name: string;
+      sentences: string;
+      genres: string[];
+      tags: string[];
+    };
+  },
+) {
+  try {
+    const res = await axiosClient().post(`/posts/${uuid}/letter`, value);
+
+    return { status: res.status === 201, data: res.data.message };
+  } catch (error) {
+    return { status: false, error };
+  }
+}


### PR DESCRIPTION
## 概要

## 紐づく issue
close #10 

## チェック項目
- [x] 過去の手紙を読みに行けること
- [ ] 過去の手紙は最後から読めること
   ⇨ ちょっと難しかったので妥協（修正できればします）
- [x] 過去の手紙は最初から読むボタンで最初から読めること
   ⇨ ページネーションで対応
- [x] 本文を書けること
- [x] 本文の入力文字数が表示されていること
- [x] 名前の記入欄があること
- [x] 名前の記入文字数が表示されていること
- [x] ジャンルの記入欄があること（オートコンプリート）
- [x] タグの記入欄があること（オートコンプリート）
- [x] 投函ボタンが有ること
- [x] 投函に成功したらトーストを表示して詳細ページに飛べるようにしてあること（実装の順番的に遷移はまだで良い）
   ⇨ 実装できたのでしました。
- [ ] 投函に失敗したらモーダルで失敗理由が表示されること
   ⇨ 失敗理由は出ないですがトーストで失敗を表示しています。
- [x] そもそも本文がなければ投函できないこと
- [x] 本文や名前が文字数オーバーしていたら投函できないこと
- [x] 本文や名前が文字数オーバーしていたら投函ボタンの近くに「文字数オーバーしています」と表示されること

### 未実装の項目

## 挙動
| PC | SP |
| --- | --- |
| <img src="https://i.gyazo.com/e80157c3eface85be34456fa2bd0fc9b.gif" width="500px" /> | <img src="https://i.gyazo.com/c2407eaf4a527af2b95383d804402521.gif" width="200px" /> |

## 補足
リファクタリングは後でできたらやります。

## 参考
