### PR TITLE
【feature】ユーザー一覧とユーザーの投稿一覧取得 close #17 #25

### DIFF
--- a/back/app/controllers/api/v1/posts_controller.rb
+++ b/back/app/controllers/api/v1/posts_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::PostsController < Api::V1::BasesController
   skip_before_action :authenticate_api_v1_user!, only: %i[index show]
 
   def index
-    posts = Post.includes(:genres, :tags, letters: :user).order(created_at: :desc)
+    posts = Post.includes(:genres, :tags, letters: :user).order(updated_at: :desc)
     page = params[:page].present? ? params[:page].to_i : 1
     posts_paginated = posts.per_page(page)
     render json: { posts: posts_paginated.map(&:as_custom_index_json), all_count: Post.all.count }, status: :ok

--- a/back/app/controllers/api/v1/users_controller.rb
+++ b/back/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,27 @@
+class Api::V1::UsersController < Api::V1::BasesController
+  skip_before_action :authenticate_api_v1_user!, only: %i[index show]
+  def index
+    users = User.all
+    render json: users.map(&:as_custom_index_json), status: :ok
+  end
+
+  def show
+    posts = User.includes(letters: :user).find_by(uuid: params[:id]).posts
+    render json: { posts: posts.map(&:as_custom_index_json), all_count: posts.count }, status: :ok
+  end
+
+  def update
+    user = current_api_v1_user
+    if user.update(user_params)
+      head :success
+    else
+      head :bad_request
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name)
+  end
+end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ActiveRecord::Base
   include DeviseTokenAuth::Concerns::User
 
   has_many :letters, dependent: :destroy
+  has_many :posts, through: :letters
 
   before_validation :set_default_uuid, on: :create
 
@@ -30,5 +31,12 @@ class User < ActiveRecord::Base
     new_uuid = SecureRandom.uuid
     encode_uuid = Base64.urlsafe_encode64([new_uuid.delete('-')].pack("H*")).tr('=', '')
     self.uuid = encode_uuid
+  end
+
+  def as_custom_index_json
+    {
+      uuid: uuid,
+      name: name
+    }
   end
 end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
           resource :tags, only: [:show]
         end
       end
+      resources :users, only: [:index, :show, :update]
     end
   end
   root 'application#index'


### PR DESCRIPTION
## 概要
ユーザー周りのコントローラを作成しました。
- ユーザー一覧
- ユーザーが投稿/返信した一覧

## 紐づく issue
close #17 
close #25 

## チェック項目
- [ ] 投稿しているユーザーの総数が取得できていること
   ⇨ 無限スクロールを行うので未実装
- [x] 各ユーザー情報が取得できること
   - [x] ユーザーのid
      ⇨ uuidの取得に変更
   - [x] ユーザー名
- [x] ユーザー名が表示取得できる
- [ ] ユーザーが使った名前一覧が取得できる
   ⇨ 現打開では未実装
- [x] ユーザーが最初に投稿した手紙一覧を取得できる
- [x] ユーザーが返信した手紙一覧を取得できる

### 未実装の項目
- [ ] 投稿しているユーザーの総数が取得できていること
   ⇨ 無限スクロールを行うので未実装

## 挙動
| PC |
| --- |
| <img src="https://i.gyazo.com/413621edc03411330107155d1e933451.png" width="400px" /> |

## 補足
一気にやってしまいました。反省。
反省ばかりの人生だ…

## 参考
過去リポジトリ