### PR TITLE
【feature】ユーザーページ作成 close #26

### DIFF
--- a/back/app/controllers/api/v1/users_controller.rb
+++ b/back/app/controllers/api/v1/users_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::UsersController < Api::V1::BasesController
   end
 
   def show
-    posts = User.includes(letters: :posts).find_by(uuid: params[:id]).posts
+    posts = User.includes(letters: :post).find_by(uuid: params[:id]).posts
 
     tab_posts = []
     case params[:tab]
@@ -22,7 +22,12 @@ class Api::V1::UsersController < Api::V1::BasesController
     else
       tab_posts = posts
     end
-    render json: { tab_posts: tab_posts.map(&:as_custom_index_json), all_count: tab_posts.count }, status: :ok
+    render json: { posts: tab_posts.map(&:as_custom_index_json), all_count: tab_posts.count }, status: :ok
+  end
+
+  def show_user
+    user = User.find_by(uuid: params[:id])
+    render json: user.name, status: :ok
   end
 
   def update

--- a/back/app/controllers/api/v1/users_controller.rb
+++ b/back/app/controllers/api/v1/users_controller.rb
@@ -33,7 +33,7 @@ class Api::V1::UsersController < Api::V1::BasesController
   def update
     user = current_api_v1_user
     if user.update(user_params)
-      head :success
+      head :ok
     else
       head :bad_request
     end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -12,7 +12,9 @@ Rails.application.routes.draw do
           resource :tags, only: [:show]
         end
       end
-      resources :users, only: [:index, :show, :update]
+      resources :users, only: [:index, :show, :update] do
+        get 'show_user', on: :member
+      end
     end
   end
   root 'application#index'

--- a/front/src/app/posts/page.tsx
+++ b/front/src/app/posts/page.tsx
@@ -29,7 +29,14 @@ export default function Posts() {
 
   const pages = [];
   for (let i = 1; i <= cnt; i++) {
-    pages.push(<Letters key={i} index={i} onClick={handleClick} setPostsCount={setPostsCount} />);
+    pages.push(
+      <Letters
+        key={i}
+        url={`/posts?page=${i}`}
+        onClick={handleClick}
+        setPostsCount={setPostsCount}
+      />,
+    );
   }
 
   const fetchUserData = useCallback(async () => {

--- a/front/src/app/users/[id]/page.tsx
+++ b/front/src/app/users/[id]/page.tsx
@@ -79,18 +79,21 @@ export default function User({ params: { id } }: { params: { id: string } }) {
           <button className="rounded bg-sky-500 px-2 py-1 text-sm text-white">名前を変える</button>
         )}
       </section>
-      <section className="sticky my-4 text-center">
-        <SegmentedControl
-          value={tabType}
-          color="blue"
-          onChange={(value) => setTabType(value as TabType)}
-          data={[
-            { label: "１通目", value: TabType.First },
-            { label: "返信", value: TabType.Reply },
-          ]}
-        />
+      <section className="relative">
+        <div className="sticky top-0 z-10 my-4 text-center">
+          <SegmentedControl
+            value={tabType}
+            color="blue"
+            className="border border-sky-500"
+            onChange={(value) => setTabType(value as TabType)}
+            data={[
+              { label: "１通目", value: TabType.First },
+              { label: "返信", value: TabType.Reply },
+            ]}
+          />
+        </div>
+        {pages}
       </section>
-      <section>{pages}</section>
     </article>
   );
 }

--- a/front/src/app/users/[id]/page.tsx
+++ b/front/src/app/users/[id]/page.tsx
@@ -1,13 +1,17 @@
 "use client";
 
-import { SegmentedControl } from "@mantine/core";
+import { Button, SegmentedControl } from "@mantine/core";
+import { useForm } from "@mantine/form";
+import { useDisclosure } from "@mantine/hooks";
 import { useEffect, useRef, useState } from "react";
 import { useRecoilValue } from "recoil";
-import useSWR from "swr";
+import useSWR, { mutate } from "swr";
 
-import { Letters } from "@/features/posts";
-import { userState } from "@/hooks";
+import { ValidError } from "@/components/forms";
+import { DetailModal, Letters } from "@/features/posts";
+import { useNotification, userState } from "@/hooks";
 import { axiosClient } from "@/lib";
+import { NotificationType } from "@/types";
 
 const fetcher = (url: string) =>
   axiosClient()
@@ -26,7 +30,45 @@ export default function User({ params: { id } }: { params: { id: string } }) {
   const currentPostAllCount = useRef(1);
   const currentUuid = useRef<string>("");
   const [cnt, setCnt] = useState(1);
+  const [editName, setEditName] = useState(false);
+  const [opened, { open, close }] = useDisclosure(false);
+  const { setNewNotification } = useNotification();
   const PER_PAGE = 12;
+  const NAME_MAX_LENGTH = 10;
+
+  const form = useForm({
+    initialValues: {
+      name: "",
+    },
+    validate: {
+      name: (value) => {
+        if (value.length > NAME_MAX_LENGTH) {
+          return "名前は10文字以内がいいな";
+        }
+      },
+    },
+  });
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const { scrollHeight, clientHeight, scrollTop } = document.documentElement;
+      const isScrolledToBottom = scrollHeight - scrollTop === clientHeight;
+      const allPage = Math.ceil(currentPostAllCount.current / PER_PAGE);
+      if (isScrolledToBottom && cnt + 1 <= allPage) {
+        setCnt((prev) => prev + 1);
+      }
+    };
+
+    window.addEventListener("scroll", handleScroll);
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, []);
+
+  if (!data) {
+    return <div>ちょっとまってね</div>;
+  }
 
   const setPostsCount = (allPostsCount: number) => {
     currentPostAllCount.current = allPostsCount;
@@ -50,50 +92,104 @@ export default function User({ params: { id } }: { params: { id: string } }) {
     );
   }
 
-  useEffect(() => {
-    const handleScroll = () => {
-      const { scrollHeight, clientHeight, scrollTop } = document.documentElement;
-      const isScrolledToBottom = scrollHeight - scrollTop === clientHeight;
-      const allPage = Math.ceil(currentPostAllCount.current / PER_PAGE);
-      if (isScrolledToBottom && cnt + 1 <= allPage) {
-        setCnt((prev) => prev + 1);
+  const toggleEditName = () => {
+    setEditName(!editName);
+  };
+
+  const handleSubmit = async () => {
+    const { name } = form.getValues();
+
+    try {
+      const res = await axiosClient().patch(`/users/${id}`, { name });
+      if (res.status !== 200) {
+        throw new Error(res.data.message);
       }
-    };
+      mutate(`/users/${id}/show_user`);
+      setEditName(false);
+      setNewNotification({
+        title: "せいこう！",
+        message: "名前を更新したよ",
+        type: NotificationType.SUCCESS,
+      });
+    } catch (error) {
+      setNewNotification({
+        title: "しっぱい...",
+        message: "名前を更新できなかったよ",
+        type: NotificationType.ERROR,
+      });
+    }
+  };
 
-    window.addEventListener("scroll", handleScroll);
-
-    return () => {
-      window.removeEventListener("scroll", handleScroll);
-    };
-  }, []);
-
-  if (!data) {
-    return <div>ちょっとまってね</div>;
-  }
+  const isNameLengthValid = form.getValues().name.length <= NAME_MAX_LENGTH;
 
   return (
-    <article className="relative h-full">
-      <section className="flex items-center justify-between">
-        <h1>{data} さんの世界</h1>
-        {user.uuid === id && (
-          <button className="rounded bg-sky-500 px-2 py-1 text-sm text-white">名前を変える</button>
-        )}
-      </section>
-      <section className="relative">
-        <div className="sticky top-0 z-10 my-4 text-center">
-          <SegmentedControl
-            value={tabType}
-            color="blue"
-            className="border border-sky-500"
-            onChange={(value) => setTabType(value as TabType)}
-            data={[
-              { label: "１通目", value: TabType.First },
-              { label: "返信", value: TabType.Reply },
-            ]}
-          />
-        </div>
-        {pages}
-      </section>
-    </article>
+    <>
+      <article className="relative h-full">
+        <section className="flex flex-col items-center justify-between gap-2">
+          {editName ? (
+            <form onSubmit={form.onSubmit(handleSubmit)} className="flex flex-col">
+              <input
+                id="name"
+                placeholder="名もなき人"
+                name="name"
+                className={`max-w-[16rem] focus:outline-none ${isNameLengthValid ? "" : "text-red-400"}`}
+                onChange={form.getInputProps("name").onChange}
+              />
+              <p
+                className={`shrink text-end text-sm text-gray-500 ${isNameLengthValid ? "" : "text-red-400"}`}
+              >
+                {form.getValues().name.length}/{NAME_MAX_LENGTH}文字
+              </p>
+              <ValidError errorMsg={[form.errors.name]} />
+              <div className="flex items-center justify-between">
+                <Button type="submit" variant="filled" size="xs" className="w-16">
+                  更新
+                </Button>
+                <Button
+                  variant="filled"
+                  size="xs"
+                  className="w-16"
+                  type="button"
+                  onClick={() => toggleEditName()}
+                >
+                  戻す
+                </Button>
+              </div>
+            </form>
+          ) : (
+            <h1>{data} さんの世界</h1>
+          )}
+          {user.uuid === id && !editName && (
+            <Button variant="filled" size="xs" onClick={() => toggleEditName()}>
+              名前を変える
+            </Button>
+          )}
+        </section>
+        <section className="relative">
+          <div className="sticky top-0 z-10 my-4 text-center">
+            <SegmentedControl
+              value={tabType}
+              color="blue"
+              className="border border-sky-500"
+              onChange={(value) => setTabType(value as TabType)}
+              data={[
+                { label: "１通目", value: TabType.First },
+                { label: "返信", value: TabType.Reply },
+              ]}
+            />
+          </div>
+          <div className="my-12 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3">
+            {pages}
+          </div>
+        </section>
+      </article>
+      <DetailModal
+        opened={opened}
+        onClose={close}
+        uuid={currentUuid.current}
+        lettersCount={currentPostAllCount.current}
+        isReadLetter={true}
+      />
+    </>
   );
 }

--- a/front/src/app/users/[id]/page.tsx
+++ b/front/src/app/users/[id]/page.tsx
@@ -1,10 +1,96 @@
+"use client";
+
+import { SegmentedControl } from "@mantine/core";
+import { useEffect, useRef, useState } from "react";
+import { useRecoilValue } from "recoil";
+import useSWR from "swr";
+
+import { Letters } from "@/features/posts";
+import { userState } from "@/hooks";
+import { axiosClient } from "@/lib";
+
+const fetcher = (url: string) =>
+  axiosClient()
+    .get(url)
+    .then((res) => res.data);
+
+enum TabType {
+  First = "first",
+  Reply = "reply",
+}
+
 export default function User({ params: { id } }: { params: { id: string } }) {
+  const { data } = useSWR(`/users/${id}/show_user`, fetcher);
+  const user = useRecoilValue(userState);
+  const [tabType, setTabType] = useState<TabType>(TabType.First);
+  const currentPostAllCount = useRef(1);
+  const currentUuid = useRef<string>("");
+  const [cnt, setCnt] = useState(1);
+  const PER_PAGE = 12;
+
+  const setPostsCount = (allPostsCount: number) => {
+    currentPostAllCount.current = allPostsCount;
+  };
+
+  const handleClick = (uuid: string, lettersCount: number) => {
+    open();
+    currentUuid.current = uuid;
+    currentPostAllCount.current = lettersCount;
+  };
+
+  const pages = [];
+  for (let i = 1; i <= cnt; i++) {
+    pages.push(
+      <Letters
+        key={i}
+        url={`/users/${id}?tag=${tabType}&page=${i}`}
+        onClick={handleClick}
+        setPostsCount={setPostsCount}
+      />,
+    );
+  }
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const { scrollHeight, clientHeight, scrollTop } = document.documentElement;
+      const isScrolledToBottom = scrollHeight - scrollTop === clientHeight;
+      const allPage = Math.ceil(currentPostAllCount.current / PER_PAGE);
+      if (isScrolledToBottom && cnt + 1 <= allPage) {
+        setCnt((prev) => prev + 1);
+      }
+    };
+
+    window.addEventListener("scroll", handleScroll);
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, []);
+
+  if (!data) {
+    return <div>ちょっとまってね</div>;
+  }
+
   return (
-    <article>
-      <section>
-        <h1>ユーザーページ</h1>
-        <p>ユーザーID: {id}</p>
+    <article className="relative h-full">
+      <section className="flex items-center justify-between">
+        <h1>{data} さんの世界</h1>
+        {user.uuid === id && (
+          <button className="rounded bg-sky-500 px-2 py-1 text-sm text-white">名前を変える</button>
+        )}
       </section>
+      <section className="sticky my-4 text-center">
+        <SegmentedControl
+          value={tabType}
+          color="blue"
+          onChange={(value) => setTabType(value as TabType)}
+          data={[
+            { label: "１通目", value: TabType.First },
+            { label: "返信", value: TabType.Reply },
+          ]}
+        />
+      </section>
+      <section>{pages}</section>
     </article>
   );
 }

--- a/front/src/components/forms/input/index.tsx
+++ b/front/src/components/forms/input/index.tsx
@@ -1,9 +1,11 @@
 export default function Input({
   onChange,
   value,
+  placeholder = "名もなき人",
 }: {
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   value: string;
+  placeholder?: string;
 }) {
   const MAX_LENGTH = 10;
   const nameLength = value.length;
@@ -12,7 +14,7 @@ export default function Input({
     <div className="relative flex w-full items-center justify-start">
       <input
         id="name"
-        placeholder="名もなき人"
+        placeholder={placeholder}
         name="name"
         className={`w-2/3 max-w-[16rem] focus:outline-none ${isNameLengthValid ? "" : "text-red-400"}`}
         onChange={onChange}

--- a/front/src/components/ui/notification/index.tsx
+++ b/front/src/components/ui/notification/index.tsx
@@ -46,7 +46,7 @@ export default function Notification() {
       variants={variants}
       initial="hidden"
       animate={notification.open ? "visible" : "hidden"}
-      className="fixed right-0 top-16 z-10 ml-auto w-2/3 max-w-72"
+      className={`fixed right-0 top-16 z-10 ml-auto w-2/3 max-w-72 ${notification.open ? "" : "hidden"}`}
     >
       <Mantine.Notification
         title={notification.title}

--- a/front/src/features/posts/letters/index.tsx
+++ b/front/src/features/posts/letters/index.tsx
@@ -12,15 +12,15 @@ const fetcher = (url: string) =>
     .then((res) => res.data);
 
 export const Letters = memo(function Letters({
-  index,
+  url,
   onClick,
   setPostsCount,
 }: {
-  index: number;
+  url: string;
   onClick: (uuid: string, lettersCount: number) => void;
   setPostsCount: (allPostsCount: number) => void;
 }) {
-  const { data } = useSWR(`/posts?page=${index}`, fetcher);
+  const { data } = useSWR(url, fetcher);
 
   if (!data) {
     return;


### PR DESCRIPTION
## 概要
ユーザーページを作成しました。

## 紐づく issue
close #26

## チェック項目
- [x] ユーザー名が表示されている
- [ ] ユーザーが使った名前一覧が見れる
   - [ ] 名前をクリックすると書いた手紙が投函されている投稿が表示される
   - [ ] 手紙をクリックすると手紙の情報が見れて、更に投稿詳細ページ遷移のボタンが表示される
   ⇨ 必要なのか要検討
- [x] ユーザーが最初に投稿した手紙一覧が見れる
   - [x] 手紙をクリックすると手紙の情報が見れて、更に投稿詳細ページ遷移のボタンが表示される
- [x] ユーザーが返信した手紙一覧が見える
   - [x] 手紙をクリックすると手紙の情報が見れて、更に投稿詳細ページ遷移のボタンが表示される

### 未実装の項目
- [ ] ユーザーが使った名前一覧が見れる
   - [ ] 名前をクリックすると書いた手紙が投函されている投稿が表示される
   - [ ] 手紙をクリックすると手紙の情報が見れて、更に投稿詳細ページ遷移のボタンが表示される
   ⇨ 必要なのか要検討

## 挙動
環境バグか上手く表示されないので本環境で表示が正常か試したいです。
